### PR TITLE
update spring boot version to 2.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.13</version> <!-- need to be repeated in properties section for technical purposes -->
+        <version>2.5.14</version> <!-- need to be repeated in properties section for technical purposes -->
         <relativePath/> <!-- lookup parent from repository and not the filesystem -->
     </parent>
 
@@ -65,7 +65,7 @@
 
 		<!-- version properties -->
 		<!-- framework and base stuff -->
-		<spring.boot.version>2.5.13</spring.boot.version>
+		<spring.boot.version>2.5.14</spring.boot.version>
 		<spring.cloud.version>2020.0.3</spring.cloud.version>
 		<spring.version>5.3.12</spring.version>
 		<spring.feign.version>3.0.5</spring.feign.version>


### PR DESCRIPTION
Updates the Spring Boot Version to 2.5.14 due to a CVE for one of its sub-dependencies in the previous version (spring-security-config:5.5.6)