### PR TITLE
update spring version to 5.3.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<!-- framework and base stuff -->
 		<spring.boot.version>2.5.14</spring.boot.version>
 		<spring.cloud.version>2020.0.3</spring.cloud.version>
-		<spring.version>5.3.12</spring.version>
+		<spring.version>5.3.20</spring.version>
 		<spring.feign.version>3.1.3</spring.feign.version>
 		<springdoc.version>1.6.6</springdoc.version>
 		<springfox.version>2.9.2</springfox.version>


### PR DESCRIPTION
Updating to Spring Version 5.3.20 due to the findings in https://avd.aquasec.com/nvd/2022/cve-2022-22965/ 