### PR TITLE
Revert test models back to BAMM version 1.0.0

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/SparqlQueries.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/SparqlQueries.java
@@ -41,8 +41,8 @@ public class SparqlQueries {
    public static final String BAMM_ASPECT_URN_REGEX = "urn:bamm:io.openmanufacturing:meta-model:\\d\\.\\d\\.\\d#Aspect";
    public static final String ALL_BAMM_ASPECT_URN_PREFIX = "urn:bamm:io.openmanufacturing:([a-z]|-)+:\\d\\.\\d\\.\\d#";
    public static final String BAMM_ASPECT_URN_PREFIX = "urn:bamm:io.openmanufacturing:meta-model:\\d\\.\\d\\.\\d#";
-   public static final String BAMM_PREFERRED_NAME = "urn:bamm:io.openmanufacturing:meta-model:2.0.0#preferredName";
-   public static final String BAMM_DESCRIPTION = "urn:bamm:io.openmanufacturing:meta-model:2.0.0#description";
+   public static final String BAMM_PREFERRED_NAME = "urn:bamm:io.openmanufacturing:meta-model:1.0.0#preferredName";
+   public static final String BAMM_DESCRIPTION = "urn:bamm:io.openmanufacturing:meta-model:1.0.0#description";
    public static final Property STATUS_PROPERTY = ResourceFactory.createProperty( AUXILIARY_NAMESPACE, "status" );
 
    private static final String DELETE_BY_URN_QUERY =

--- a/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/ModelWithReferenceToTraceability.ttl
+++ b/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/ModelWithReferenceToTraceability.ttl
@@ -19,10 +19,10 @@
 ###############################################################
 
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .
-@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .
-@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .
-@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#> .
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#> .
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#> .
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:1.0.0#> .
 @prefix traceability: <urn:bamm:org.eclipse.tractusx.traceability:0.1.1#> .
 @prefix : <urn:bamm:org.eclipse.tractusx.modelwithreferencetotraceability:0.1.1#> .
 

--- a/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/Traceability.ttl
+++ b/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/Traceability.ttl
@@ -19,10 +19,10 @@
 ###############################################################
 
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .
-@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .
-@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .
-@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:2.0.0#> .
+@prefix bamm: <urn:bamm:io.openmanufacturing:meta-model:1.0.0#> .
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#> .
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#> .
+@prefix bamm-e: <urn:bamm:io.openmanufacturing:entity:1.0.0#> .
 @prefix : <urn:bamm:org.eclipse.tractusx.traceability:0.1.1#> .
 
 :Traceability a bamm:Aspect ;

--- a/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/ValidModelForApiTests.ttl
+++ b/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/ValidModelForApiTests.ttl
@@ -19,10 +19,10 @@
 ###############################################################
 
 @prefix :       <{{URN_PREFIX}}> .
-@prefix bamm:   <urn:bamm:io.openmanufacturing:meta-model:2.0.0#> .
-@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:2.0.0#> .
+@prefix bamm:   <urn:bamm:io.openmanufacturing:meta-model:1.0.0#> .
+@prefix bamm-c: <urn:bamm:io.openmanufacturing:characteristic:1.0.0#> .
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
-@prefix unit: <urn:bamm:io.openmanufacturing:unit:2.0.0#> .
+@prefix unit: <urn:bamm:io.openmanufacturing:unit:1.0.0#> .
 
 :Movement a bamm:Aspect ;
     bamm:name "Movement" ;


### PR DESCRIPTION
This commit reverts the test models back to BAMM version 1.0.0.