### PR TITLE
URN filter endpoint

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/AspectModelService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/AspectModelService.java
@@ -6,6 +6,7 @@ package org.eclipse.tractusx.semantics.hub;
 
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.eclipse.tractusx.semantics.hub.domain.ModelPackageStatus;
 import org.eclipse.tractusx.semantics.hub.domain.ModelPackageUrn;
@@ -20,6 +21,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Lists;
 
 import io.openmanufacturing.sds.aspectmodel.resolver.services.VersionedModel;
 import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
@@ -167,6 +169,19 @@ public class AspectModelService implements ModelsApiDelegate {
       }
 
       return new ResponseEntity( result.get(), responseHeaders, HttpStatus.OK );
+   }
+
+   @Override
+   public ResponseEntity<SemanticModelList> getModelListByUrns(Integer pageSize, Integer page, List<String> requestBody) {
+      List<AspectModelUrn> urnList = Lists.transform(requestBody, (String urn) -> AspectModelUrn.fromUrn(urn));
+
+      final SemanticModelList models = persistenceLayer.findModelListByUrns( urnList, page, pageSize );
+
+      if ( models == null ) {
+         return new ResponseEntity<>( HttpStatus.NOT_FOUND );
+      }
+
+      return new ResponseEntity<SemanticModelList>( models, HttpStatus.OK );
    }
 
    private Aspect getBamAspect( String urn ) {

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/PersistenceLayer.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/PersistenceLayer.java
@@ -20,6 +20,8 @@
 
 package org.eclipse.tractusx.semantics.hub.persistence;
 
+import java.util.List;
+
 import javax.annotation.Nullable;
 
 import org.eclipse.tractusx.semantics.hub.domain.ModelPackageStatus;
@@ -59,4 +61,6 @@ public interface PersistenceLayer {
    void deleteModelsPackage( ModelPackageUrn urn );
 
    boolean echo();
+
+   public SemanticModelList findModelListByUrns(List<AspectModelUrn> urns, int page, int pageSize);
 }

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/SparqlQueries.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/SparqlQueries.java
@@ -21,11 +21,31 @@ package org.eclipse.tractusx.semantics.hub.persistence.triplestore;
 
 import org.eclipse.tractusx.semantics.hub.domain.ModelPackageStatus;
 import org.eclipse.tractusx.semantics.hub.domain.ModelPackageUrn;
+
+import com.google.common.collect.Lists;
+
+import ch.qos.logback.core.pattern.LiteralConverter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.datatypes.BaseDatatype;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.xsd.impl.XSDPlainType;
+import org.apache.jena.graph.impl.AdhocDatatype;
 import org.apache.jena.query.ParameterizedSparqlString;
 import org.apache.jena.query.Query;
+import org.apache.jena.query.QuerySolutionMap;
+import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFList;
+import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.ResourceFactory;
+import org.apache.jena.rdf.model.impl.RDFListImpl;
+import org.apache.jena.reasoner.rulesys.FunctorDatatype;
 import org.apache.jena.update.UpdateRequest;
 
 import io.openmanufacturing.sds.aspectmodel.urn.AspectModelUrn;
@@ -89,6 +109,23 @@ public class SparqlQueries {
                + "      FILTER ( regex(str(?bammAspect), ?bammAspectUrn, \"\") && ( str(?aspect) = ?urn )\n"
                + "            && (str(?s) = ?packageUrn) )\n"
                + "  }";
+
+   private static final String FIND_BY_MULTIPLE_URNS_QUERY =
+         "SELECT DISTINCT ?aspect (?status as ?statusResult)\n"
+               + "WHERE\n"
+               + "  {\n"
+               + "      VALUES (?urns) { ?urnParamList } \n"
+               + "      VALUES (?packageUrns) { ?packageUrnParamList } \n"
+               + "      bind( $bammAspectUrnParam as ?bammAspectUrn )\n"
+               + "      ?aspect a ?bammAspect .\n"
+               + "      ?s aux:status ?status .\n"
+               + "      FILTER ( regex(str(?bammAspect), ?bammAspectUrn, \"\") \n"
+               + "      && ( str(?aspect) IN (?urns) )  \n"
+               + "      && ( str(?s) IN (?packageUrns)) ) \n"
+               + "  }"
+               + "ORDER BY lcase(str(?aspect))\n"
+               + "OFFSET  $offsetParam\n"
+               + "LIMIT   $limitParam";
 
    private static final String FIND_BY_PACKAGE_URN_QUERY =
          "SELECT (?status as ?statusResult)\n"
@@ -154,6 +191,22 @@ public class SparqlQueries {
            + "FILTER ( !bound(?namespaceFilter) || contains(str(?aspect), ?namespaceFilter ) )\n"
            + "}\n";
 
+   private static final String FILTER_QUERY_MINIMAL_WHERE_CLAUSE_SELECTIVE = "WHERE {\n"
+           + "BIND($bammAspectUrnRegexParam AS ?bammAspectUrnRegex)\n"
+           + "BIND(iri($bammFieldToSearchInParam) AS ?bammFieldToSearchIn)\n"
+           + "BIND($bammFieldSearchValueParam AS ?bammFieldSearchValue)\n"
+           + "BIND($statusFilterParam AS ?statusFilter)\n"
+           + "BIND($namespaceFilterParam AS ?namespaceFilter)\n"
+           + "VALUES (?urns) { ?urnParamList } \n"
+           + "?aspect  a ?bammAspect .\n"
+           + "FILTER regex(str(?bammAspect), ?bammAspectUrnRegex, \"\")\n"
+           + "BIND(iri(concat(strbefore(str(?aspect ), \"#\"), \"#\")) AS ?package)\n"
+           + "?package  aux:status  ?status\n"
+           + "FILTER ( !bound(?statusFilter) || contains(str(?status), ?statusFilter) )\n"
+           + "FILTER ( !bound(?namespaceFilter) || contains(str(?aspect), ?namespaceFilter ) )\n"
+           + "FILTER ( str(?aspect) IN (?urns) ) "
+           + "}\n";
+
    private static final String FIND_ALL_MINIMAL_QUERY =
            "SELECT DISTINCT ?aspect (?status as ?statusResult)\n"
                    + FILTER_QUERY_MINIMAL_WHERE_CLAUSE
@@ -164,6 +217,10 @@ public class SparqlQueries {
    private static final String COUNT_ASPECT_MODELS_MINIMAL_QUERY =
            "SELECT (count(DISTINCT ?aspect) as ?aspectModelCount)\n"
                    + FILTER_QUERY_MINIMAL_WHERE_CLAUSE;
+
+   private static final String COUNT_ASPECT_MODELS_MINIMAL_QUERY_SELECTIVE =
+            "SELECT (count(DISTINCT ?aspect) as ?aspectModelCount)\n"
+                  + FILTER_QUERY_MINIMAL_WHERE_CLAUSE_SELECTIVE;
 
    private SparqlQueries() {
    }
@@ -176,6 +233,26 @@ public class SparqlQueries {
       return pss.asQuery();
    }
 
+   public static Query buildFindListByUrns( final List<AspectModelUrn> urns, int page, int pageSize ) {
+      final ParameterizedSparqlString pss = create( FIND_BY_MULTIPLE_URNS_QUERY );
+
+      List<RDFNode> urnList = new ArrayList<>();
+      List<RDFNode> modelPackageUrnList = new ArrayList<>();
+
+      urns.forEach((AspectModelUrn urn) -> {
+         urnList.add(ResourceFactory.createStringLiteral(urn.toString()));
+         modelPackageUrnList.add(ResourceFactory.createStringLiteral(ModelPackageUrn.fromUrn(urn).getUrn()));
+      });
+
+      pss.setValues("urnParamList", urnList);
+      pss.setLiteral( "$bammAspectUrnParam", BAMM_ASPECT_URN_REGEX );
+      pss.setValues( "packageUrnParamList", modelPackageUrnList );
+      pss.setLiteral("offsetParam", getOffset(page, pageSize));
+      pss.setLiteral("limitParam", pageSize);
+      
+      return pss.asQuery();
+   }
+
    public static Query buildCountAspectModelsQuery( String namespaceFilter, String nameFilter, String nameType,
          ModelPackageStatus status ) {
       if(StringUtils.isNotBlank(nameType) && StringUtils.isNotBlank(nameFilter)){
@@ -183,6 +260,24 @@ public class SparqlQueries {
                  nameFilter, nameType, status ).asQuery();
       }
       return buildMinimalQuery(COUNT_ASPECT_MODELS_MINIMAL_QUERY, namespaceFilter, status).asQuery();
+   }
+
+   public static Query buildCountSelectiveAspectModelsQuery( String namespaceFilter, String nameFilter, String nameType,
+         ModelPackageStatus status, List<AspectModelUrn> urns ) {
+      ParameterizedSparqlString pss = buildMinimalQuery(COUNT_ASPECT_MODELS_MINIMAL_QUERY_SELECTIVE, namespaceFilter, status);
+      
+      List<RDFNode> urnList = new ArrayList<>();
+      List<RDFNode> modelPackageUrnList = new ArrayList<>();
+
+      urns.forEach((AspectModelUrn urn) -> {
+         urnList.add(ResourceFactory.createStringLiteral(urn.toString()));
+         modelPackageUrnList.add(ResourceFactory.createStringLiteral(ModelPackageUrn.fromUrn(urn).getUrn()));
+      });
+
+      pss.setValues("urnParamList", urnList);
+      pss.setValues( "packageUrnParamList", modelPackageUrnList );
+
+      return pss.asQuery();
    }
 
    public static Query buildFindByPackageQuery( final ModelPackageUrn modelsPackage ) {

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -172,6 +172,28 @@ public class TripleStorePersistence implements PersistenceLayer {
       deleteByUrn( urn );
    }
 
+   @Override
+   public SemanticModelList findModelListByUrns(List<AspectModelUrn> urns, int page, int pageSize) {
+      final Query query = SparqlQueries.buildFindListByUrns( urns, page, pageSize );
+      final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         rdfConnection.queryResultSet( query, resultSet -> {
+            final List<QuerySolution> querySolutions = ResultSetFormatter.toList( resultSet );
+            aspectModels.set( TripleStorePersistence.aspectModelFrom( querySolutions ) );
+         } );
+      }
+      int totalSemanticModelCount = getSelectiveItemsCount( null, null, null, null, urns );
+      int totalPages =  getTotalPages(totalSemanticModelCount, pageSize );
+      SemanticModelList modelList = new SemanticModelList();
+      List<SemanticModel> semanticModels = aspectModels.get();
+      modelList.setCurrentPage( page );
+      modelList.setItemCount( semanticModels.size() );
+      modelList.setTotalPages( totalPages );
+      modelList.setTotalItems( totalSemanticModelCount );
+      modelList.setItems( aspectModels.get() );
+      return modelList;
+   }
+
    public boolean echo() {
       final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build();
 
@@ -206,6 +228,21 @@ public class TripleStorePersistence implements PersistenceLayer {
          AtomicReference<Integer> count = new AtomicReference<>();
          rdfConnection.querySelect(
                SparqlQueries.buildCountAspectModelsQuery( namespaceFilter, nameFilter, nameType, status ),
+               querySolution -> {
+                  int countResult = querySolution.getLiteral( "aspectModelCount" ).getInt();
+                  count.set( countResult );
+               } );
+         return count.get();
+      }
+   }
+
+   private Integer getSelectiveItemsCount( @Nullable String namespaceFilter, @Nullable String nameFilter,
+         @Nullable String nameType,
+         @Nullable ModelPackageStatus status, List<AspectModelUrn> urns ) {
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         AtomicReference<Integer> count = new AtomicReference<>();
+         rdfConnection.querySelect(
+               SparqlQueries.buildCountSelectiveAspectModelsQuery( namespaceFilter, nameFilter, nameType, status, urns ),
                querySolution -> {
                   int countResult = querySolution.getLiteral( "aspectModelCount" ).getInt();
                   count.set( countResult );

--- a/backend/src/main/resources/static/semantic-hub-openapi.yaml
+++ b/backend/src/main/resources/static/semantic-hub-openapi.yaml
@@ -133,6 +133,7 @@ paths:
       tags:
         - SemanticHub
       operationId: getModelListByUrns
+      description: This endpoint allows to filter for a specific set of URNs. The endpoint returns the metadata, such as the model status. For URNs that are not in the database there is no entry in the result set. Therefore, a search array with 10 URNs can result in a response containing 9 or less result entries.
       parameters:
         - in: query
           name: pageSize

--- a/backend/src/main/resources/static/semantic-hub-openapi.yaml
+++ b/backend/src/main/resources/static/semantic-hub-openapi.yaml
@@ -128,7 +128,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /models/bulk:
+  /models/lookup:
     post:
       tags:
         - SemanticHub

--- a/backend/src/main/resources/static/semantic-hub-openapi.yaml
+++ b/backend/src/main/resources/static/semantic-hub-openapi.yaml
@@ -128,6 +128,49 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /models/bulk:
+    post:
+      tags:
+        - SemanticHub
+      operationId: getModelListByUrns
+      parameters:
+        - in: query
+          name: pageSize
+          required: true
+          schema:
+            default: 10
+            type: integer
+            enum:
+              - 10
+              - 50
+              - 100
+            description: Size of the pages that the results should be partitioned in
+        - in: query
+          name: page
+          required: true
+          schema:
+            default: 0
+            type: integer
+            description: The page to return
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/SemanticModelList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   '/models/{urn}':
     get:
       tags:

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
@@ -432,7 +432,7 @@ public class ModelsApiTest extends AbstractModelsApiTest{
 
         urnSearchArrayNonExistingEntry.add("urn:bamm:org.eclipse.tractusx.test_model_list_by_urns_50:1.0.0#Movement");
 
-        mvc.perform(MockMvcRequestBuilders.post("/api/v1/models/bulk" )
+        mvc.perform(MockMvcRequestBuilders.post("/api/v1/models/lookup" )
         .param("pageSize", "2")
         .param("page", "0")
         .content(new JSONArray(urnSearchArrayEvenNumbers).toString())
@@ -447,7 +447,7 @@ public class ModelsApiTest extends AbstractModelsApiTest{
         .andExpect(jsonPath("$.items[1].urn", equalTo("urn:bamm:org.eclipse.tractusx.test_model_list_by_urns_2:1.0.0#Movement")))
         .andExpect(jsonPath("$.items.length()", equalTo(2)));
 
-        mvc.perform(MockMvcRequestBuilders.post("/api/v1/models/bulk")
+        mvc.perform(MockMvcRequestBuilders.post("/api/v1/models/lookup")
         .param("pageSize", "2")
         .param("page", "1")
         .content(new JSONArray(urnSearchArrayOddNumbers).toString())
@@ -462,7 +462,7 @@ public class ModelsApiTest extends AbstractModelsApiTest{
         .andExpect(jsonPath("$.items[1].urn", equalTo("urn:bamm:org.eclipse.tractusx.test_model_list_by_urns_5:1.0.0#Movement")))
         .andExpect(jsonPath("$.items.length()", equalTo(2)));
 
-        mvc.perform(MockMvcRequestBuilders.post("/api/v1/models/bulk")
+        mvc.perform(MockMvcRequestBuilders.post("/api/v1/models/lookup")
         .content(new JSONArray(urnSearchArrayNonExistingEntry).toString())
         .contentType(MediaType.APPLICATION_JSON)
         .with(jwtTokenFactory.allRoles()))


### PR DESCRIPTION
The changes of this PR add a new endpoint to the Semantic Hub that allows to filter for a list of URNs. Only these model entries will then be returned as part of the request. Pagination is included.