### PR TITLE
Updates snakeyaml dependency to 1.33 due to CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<vavr.version>0.10.3</vavr.version>
 		<commons-io.version>2.11.0</commons-io.version>
 		<google.findbugs.version>3.0.2</google.findbugs.version>
-		<snakeyaml.version>1.31</snakeyaml.version>
+		<snakeyaml.version>1.33</snakeyaml.version>
 
 		<!-- logging -->
 		<slf4j.version>1.7.32</slf4j.version>


### PR DESCRIPTION
Updates snakeyaml dependency to 1.33 due to CVE in previous version (CVE-2022-38752).