### PR TITLE
fix cve-2022-42003 (jackson-databind)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
 		<!-- json, xml, formats, ... -->
 		<jackson.version>2.13.1</jackson.version>
-		<jackson.databind.version>2.13.4.2</jackson.databind.version>
+		<jackson.databind.version>2.14.0</jackson.databind.version>
 		<jackson.dataformat.version>2.12.7</jackson.dataformat.version>
 		<json.version>20211205</json.version>
 		<woodstoxcore.version>6.4.0</woodstoxcore.version>


### PR DESCRIPTION
Increase jackson-databind version to 2.14.0