### PR TITLE
Adjust github action release.yml File to setup with java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: release
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
           cache: maven
       - name: setup git config


### PR DESCRIPTION
Semantic-hub app is built with java 17. Therefore the release.yml needs to be updated to setup Java with version 17.