### PR TITLE
Adjust Dockerfile to include build step

### DIFF
--- a/.github/actions/generate-dependencies-notice/action.yml
+++ b/.github/actions/generate-dependencies-notice/action.yml
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+# SPDX-License-Identifier: Apache-2.0
+---
+
+name: Generate Dependencies Notice
+description: Generates dpendencies notices and integrates license texts
+inputs:
+  version:
+    description: Version of the image to publish
+    required: true
+  base-path:
+    description: Base path of the repository
+    required: true
+  maven-deps-path:
+    description: Location where to find the maven deps file
+    required: true
+  base-image-layers-path:
+    description: Location where to find the package info about the base image layers
+    required: true
+runs:
+  using: node16
+  main: index.js

--- a/.github/actions/generate-dependencies-notice/index.js
+++ b/.github/actions/generate-dependencies-notice/index.js
@@ -1,0 +1,253 @@
+/*
+Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+const https = require('https')
+const fs = require('fs')
+const path = require('path')
+const { exec } = require("child_process")
+const { parse } = require('csv-parse/sync')
+const core = require('@actions/core');
+
+
+const basePath = core.getInput('base-path');
+const relativeMavenDepsPath = core.getInput('maven-deps-path');
+const relativeBaseImageLayersPath = core.getInput('base-image-layers-path');
+
+var dashToolPath = `${basePath}/dash-tool.jar`
+var legalDirectory = `${basePath}/legal`
+var mavenDepPath = path.join(basePath, relativeMavenDepsPath)
+var baseImageLayersPath = path.join(basePath, relativeBaseImageLayersPath)
+var summaryOutputPath = `${legalDirectory}/dependencies.txt`
+var baseImageLayerMappingPath = `${legalDirectory}/baseImageLayers.txt`
+var licenseDirectory = `${legalDirectory}/licenses`
+
+main()
+
+async function main() {
+    await asyncDashToolDownload("https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST")
+
+    createDirectories()
+
+    var [baseLayerPackageList, baseLayerLicenses] = parseBaseImageLayers()
+    
+    writeBaseImageLayerMappingToFile(baseLayerPackageList)
+
+    var dashToolResponse = await runDashTool()
+
+    console.log(dashToolResponse)
+
+    var depLicenses = parseDependencies()
+
+    var spdxMapping = await fetchSPDXMapping()
+
+    var mergedLicenseList = [...new Set(baseLayerLicenses.concat(depLicenses))]
+
+    await downloadLicenses(mergedLicenseList, spdxMapping)
+}
+
+async function downloadLicenses(depLicenses, spdxMapping) {
+    return Promise.all(depLicenses.map((license) => {
+        var result = spdxMapping.licenses.find(mapping => mapping.licenseId === license)
+
+        if(result != undefined) {
+            return new Promise((resolve, reject) => {
+                https.get(result.detailsUrl, (response) => {
+                    let body = "";
+        
+                    response.on("data", (part) => {
+                        body += part;
+                    });
+        
+                    response.on("end", () => {
+                        let licenseDetailsJson = JSON.parse(body);
+
+                        fs.writeFileSync(`${licenseDirectory}/${licenseDetailsJson.licenseId}.txt`, licenseDetailsJson.licenseText, err => {
+                            if(err) {
+                                console.log(err)
+
+                                reject()
+                            }
+                        })
+
+                        console.log(`Successfully downloaded ${license}`)
+
+                        resolve()
+                    });
+                })
+            })
+        } else {
+            console.log(`WARNING: Unable to find ${license}`)
+        }
+    }))
+}
+
+function writeBaseImageLayerMappingToFile(data) {
+    fs.writeFileSync(baseImageLayerMappingPath, JSON.stringify(data), (err) => {
+        if(err) {
+            console.log(err)
+        }
+    })
+}
+
+function parseBaseImageLayers() {
+    var baseImageLayersFile = fs.readFileSync(baseImageLayersPath, (err, data) => {
+        if(err) {
+            console.log(error)
+
+            return;
+        }
+    })
+
+    var baseImageLayerJson = JSON.parse(baseImageLayersFile)
+
+    var packages = []
+    var licenses = []
+
+    for(layer of baseImageLayerJson.images[0].image.layers) {
+        for(package of layer.packages) {
+            packages.push({
+                name: package.name,
+                version: package.version,
+                proj_url: package.proj_url,
+                license: package.pkg_license
+            })
+
+            licenses = licenses.concat(extractLicensesFromLicenseStatement(package.pkg_license))
+        }
+    }
+
+    licenses = [...new Set(licenses)]
+
+    licenses = licenses.filter(l => l !== "")
+
+    return [packages, licenses]
+}
+
+function parseDependencies(licenses) {
+    var dependenciesList = fs.readFileSync(summaryOutputPath, (err, data) => {
+        if(err) {
+            console.log(error)
+
+            return;
+        }
+    })
+    var records = parse(dependenciesList, {
+        skip_empty_lines: true,
+        delimiter: ',',
+    })
+
+    var licenses = []
+
+    for(record of records) {
+        licenses = licenses.concat(extractLicensesFromLicenseStatement(record[1]))
+    }
+
+    licenses = [...new Set(licenses)]
+
+    licenses = licenses.filter(l => l !== "")
+
+    return licenses
+}
+
+function extractLicensesFromLicenseStatement(licenseString) {
+    var licenses = []
+
+    license = licenseString.replace(/[ \(\)]/g, "")
+    var splitLicense = license.split(/AND|OR|with|WITH/g)
+    for(l of splitLicense) {
+        licenses.push(l)
+    }
+
+    return licenses
+}
+
+async function fetchSPDXMapping() {
+    return new Promise((resolve, reject) => {
+        https.get("https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json", (response) => {
+            let body = "";
+
+            response.on("data", (part) => {
+                body += part;
+            });
+
+            response.on("end", () => {
+                try {
+                    let spdxMappingJson = JSON.parse(body);
+                    resolve(spdxMappingJson)
+                } catch (error) {
+                    console.error(error.message);
+                };
+            });
+        })
+    })
+}
+
+async function runDashTool() {
+    return new Promise((resolve, reject) => {
+        console.log(`Executing Dash Tool`)
+
+        exec(`java -jar ${dashToolPath} ${mavenDepPath} -summary ${summaryOutputPath}`, (error, stdout, stderr) => {
+            if (stderr) {
+                resolve(stderr)
+            }
+
+            resolve(stdout)
+        })
+    })
+}
+
+async function asyncDashToolDownload(url) {
+    return new Promise((resolve, reject) => {
+        downloadDashTool(url, resolve, reject)
+    })
+}
+
+async function downloadDashTool(url, resolve, reject) {
+    https.get(url, (response) => {
+        if (response.statusCode >= 400) {
+            reject("Could not download Dash Tool")
+        }
+
+        if (response.statusCode > 300 && response.statusCode < 400 && !!response.headers.location) {
+            downloadDashTool(response.headers.location, resolve, reject)
+        } else {
+            console.log(`Starting download of Dash Tool`)
+
+            const filePath = fs.createWriteStream(dashToolPath);
+
+            response.pipe(filePath)
+            filePath.on('finish', () => {
+                filePath.close()
+                console.log(`Downloaded Dash Tool`)
+                resolve(`Downloaded Dash Tool`)
+            })
+        }
+    })
+}
+
+function createDirectories() {
+    if(!fs.existsSync(legalDirectory)) {
+        fs.mkdirSync(legalDirectory)
+    }
+
+    if(!fs.existsSync(licenseDirectory)) {
+        fs.mkdirSync(licenseDirectory)
+    }
+}

--- a/.github/actions/generate-dependencies-notice/package-lock.json
+++ b/.github/actions/generate-dependencies-notice/package-lock.json
@@ -1,0 +1,84 @@
+{
+  "name": "generate-dependencies-notice",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "generate-dependencies-notice",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@actions/core": "^1.10.0",
+        "csv": "^6.2.7"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "dependencies": {
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "node_modules/csv": {
+      "version": "6.2.7",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-6.2.7.tgz",
+      "integrity": "sha512-W9rB5/QWqXg2rQcAOT7lDHfxhDavg1BEmy+WaxKRYowzK9Dq+7WHIJo/8Xvry7rtaWQTMgl0wkS/cfd1k9cQUg==",
+      "dependencies": {
+        "csv-generate": "^4.2.2",
+        "csv-parse": "^5.3.5",
+        "csv-stringify": "^6.2.4",
+        "stream-transform": "^3.2.2"
+      },
+      "engines": {
+        "node": ">= 0.1.90"
+      }
+    },
+    "node_modules/csv-generate": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-4.2.2.tgz",
+      "integrity": "sha512-Ah/NcMxHMqwQsuL173yp8EOzHrbLh8iyScqTy990b+TJZNjHhy7gs5FfSmyQ2arLC2QVrueO3DYJVQnibJB3WQ=="
+    },
+    "node_modules/csv-parse": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.3.5.tgz",
+      "integrity": "sha512-8O5KTIRtwmtD3+EVfW6BCgbwZqJbhTYsQZry12F1TP5RUp0sD9tp1UnCWic3n0mLOhzeocYaCZNYxOGSg3dmmQ=="
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.2.4.tgz",
+      "integrity": "sha512-RVzGaBeHl0IspzOSiNr1e7XDM7ajuESlqetQbxH2pBPplIWycx0gAVclxNEa4lc91brK6LIE0PrdEoHtZYIHIQ=="
+    },
+    "node_modules/stream-transform": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.2.2.tgz",
+      "integrity": "sha512-DHZQPNxvjU2qdQlGcpitn8pkJHQVTqdshtgXaLz6Vc5VCAognbGuuwGS5ugeqGVnyw8j4h89QcV8cwm0D1+V0A=="
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  }
+}

--- a/.github/actions/generate-dependencies-notice/package.json
+++ b/.github/actions/generate-dependencies-notice/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "generate-dependencies-notice",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@actions/core": "^1.10.0",
+    "csv": "^6.2.7"
+  }
+}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,6 +18,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
+# Docker buildfile to containerize the semantics layer
+FROM maven:3-eclipse-temurin-17-alpine AS builder
+COPY . /build
+WORKDIR /build
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:17-jre-alpine
 
 RUN apk upgrade \
@@ -34,10 +40,11 @@ USER spring:spring
 
 WORKDIR /service
 
-COPY ./target/semantic-hub*.jar app.jar
+COPY --from=builder /build/backend/target/semantic-hub*.jar app.jar
+
+COPY backend/Dockerfile *legal /legal/
 
 ENV JAVA_TOOL_OPTIONS "-Xms512m -Xmx2048m"
-
 EXPOSE 4242
 
 ENTRYPOINT [ "java","-jar","/service/app.jar" ]


### PR DESCRIPTION
These changes adjust the existing Dockerfile to include a build step for the Semantic Hub. Also it integrates a new action that parses the license info of the used dependencies, including the base image layers.