### PR TITLE
Introduce new status standardized

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/domain/ModelPackageStatus.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/domain/ModelPackageStatus.java
@@ -22,5 +22,6 @@ package org.eclipse.tractusx.semantics.hub.domain;
 public enum ModelPackageStatus {
    RELEASED,
    DRAFT,
-   DEPRECATED
+   DEPRECATED,
+   STANDARDIZED
 }

--- a/backend/src/main/resources/static/semantic-hub-openapi.yaml
+++ b/backend/src/main/resources/static/semantic-hub-openapi.yaml
@@ -406,6 +406,7 @@ components:
       enum:
         - DRAFT
         - RELEASED
+        - STANDARDIZED
         - DEPRECATED
     SemanticModelType:
       type: string

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
@@ -313,6 +313,11 @@ public class ModelsApiTest extends AbstractModelsApiTest{
          mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT") )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());
+            
+        // Transition from draft to standardized is not allowed
+        mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"STANDARDIZED") )
+          .andDo( MockMvcResultHandlers.print() )
+          .andExpect(status().isBadRequest());
 
          // transition from draft to release is allowed, delete is not allowed
          mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"RELEASED") )
@@ -328,10 +333,21 @@ public class ModelsApiTest extends AbstractModelsApiTest{
          // transition from released to draft is not allowed
          mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT") )
                  .andExpect( jsonPath( "$.error.message", is(
-                         "The package urn:bamm:org.eclipse.tractusx.model.status.transition.post:2.0.0# is already in status RELEASED and cannot be modified. Only a transition to DEPRECATED is possible." ) ) )
+                         "The package urn:bamm:org.eclipse.tractusx.model.status.transition.post:2.0.0# is already in status RELEASED and cannot be modified. Only a transition to STANDARDIZED or DEPRECATED is possible." ) ) )
                  .andExpect( status().isBadRequest() );
 
-         // transition from released to deprecated is allowed
+        // transition from released to standardized is allowed
+        mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"STANDARDIZED") )
+          .andDo( MockMvcResultHandlers.print() )
+          .andExpect(status().isOk());
+
+        // transition from standardized to draft is not allowed
+        mvc.perform(post( TestUtils.createValidModelRequest(urnPrefix),"DRAFT") )
+        .andExpect( jsonPath( "$.error.message", is(
+                "The package urn:bamm:org.eclipse.tractusx.model.status.transition.post:2.0.0# is already in status STANDARDIZED and cannot be modified. Only a transition to DEPRECATED is possible." ) ) )
+        .andExpect( status().isBadRequest() );
+
+         // transition from standardized to deprecated is allowed
          mvc.perform(
                          post( TestUtils.createValidModelRequest(urnPrefix),"DEPRECATED")
                  )
@@ -376,10 +392,15 @@ public class ModelsApiTest extends AbstractModelsApiTest{
          // transition from released to draft is not allowed
          mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix), "DRAFT") )
                  .andExpect( jsonPath( "$.error.message", is(
-                         "The package urn:bamm:org.eclipse.tractusx.model.status.transition.put:2.0.0# is already in status RELEASED and cannot be modified. Only a transition to DEPRECATED is possible." ) ) )
+                         "The package urn:bamm:org.eclipse.tractusx.model.status.transition.put:2.0.0# is already in status RELEASED and cannot be modified. Only a transition to STANDARDIZED or DEPRECATED is possible." ) ) )
                  .andExpect( status().isBadRequest() );
 
-         // transition from released to deprecated is allowed
+        // transition from released to standardized is allowed
+        mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix),"STANDARDIZED") )
+          .andDo( MockMvcResultHandlers.print() )
+          .andExpect(status().isOk());
+
+         // transition from standardized to deprecated is allowed
          mvc.perform(put( TestUtils.createValidModelRequest(urnPrefix),"DEPRECATED") )
                  .andDo( MockMvcResultHandlers.print() )
                  .andExpect(status().isOk());


### PR DESCRIPTION
This adds a new status standardized. Already released models can be transitioned into the standardized status. It is not possible to delete a standardized model.