### PR TITLE
chore: add initial version of .tractusx metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,6 @@
+product: "Semantic Hub"
+leadingRepository: "https://github.com/eclipse-tractusx/sldt-semantic-hub"
+repositories:
+  - name: "sldt-semantic-hub"
+    usage: "reference implementation of SLDT Semantic Hub"
+    url: "https://github.com/eclipse-tractusx/sldt-semantic-hub"


### PR DESCRIPTION
## Description

This PR adds an initial version of the `.tractusx` metadata file like described in [TRG 2.05](https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5).
If there are any other repositories, that are connected to the Semantic Hub, that together form a product, please point that out or add the connected repos later on

Fixes #143 
