### PR TITLE
fix:excluded guru.nidi libraries from esmf sdk

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -99,6 +99,16 @@
         <dependency>
             <groupId>org.eclipse.esmf</groupId>
             <artifactId>esmf-aspect-model-starter</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>guru.nidi</groupId>
+                    <artifactId>graphviz-java-min-deps</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.webjars.npm</groupId>
+                    <artifactId>viz.js-graphviz-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!--
             The AASX generator uses this dependency to generate AASX XML files.

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
 		<!-- semantics -->
 		<bamm.sdk.version>2.1.3</bamm.sdk.version>
-      <samm.sdk.version>2.2.2</samm.sdk.version>
+      <samm.sdk.version>2.2.3</samm.sdk.version>
 		<jena.version>4.7.0</jena.version>
 		<shacl.version>1.3.1</shacl.version>
 
@@ -333,16 +333,24 @@
 			</dependency>
 
 			<!-- Semantics Libraries -->
-			<dependency>   
-				<groupId>org.eclipse.esmf</groupId>   
-				<artifactId>esmf-aspect-model-starter</artifactId>   
+			<dependency>
+				<groupId>org.eclipse.esmf</groupId>
+				<artifactId>esmf-aspect-model-starter</artifactId>
 				<version>${samm.sdk.version}</version>
-				<!-- Exclusion of commons-text is required because of CVE https://avd.aquasec.com/nvd/2022/cve-2022-42889 -->   
-				<exclusions>      
-					<exclusion>         
-						<groupId>org.apache.commons</groupId>         
-						<artifactId>commons-text</artifactId>      
-					</exclusion>   
+				<!-- Exclusion of commons-text is required because of CVE https://avd.aquasec.com/nvd/2022/cve-2022-42889 -->
+				<exclusions>
+					<exclusion>
+						<groupId>org.apache.commons</groupId>
+						<artifactId>commons-text</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>guru.nidi</groupId>
+						<artifactId>graphviz-java-min-deps</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.webjars.npm</groupId>
+						<artifactId>viz.js-graphviz-java</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>   


### PR DESCRIPTION
Fixes

Get diagram functionality fixes for SAMM and BAMM models

- Removed duplicate transient guru.nidi dependencies.