### PR TITLE
fix:Commented get model diagram call

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/AspectModelService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/AspectModelService.java
@@ -83,11 +83,13 @@ public class AspectModelService implements ModelsApiDelegate {
 
    @Override
    public ResponseEntity<org.springframework.core.io.Resource> getModelDiagram( final String urn ) {
-      final Try<byte[]>pngBytes = sdkHelper.generatePng( urn );
-      if ( pngBytes.isFailure()  ) {
-         throw new RuntimeException( String.format( "Failed to generate example payload for urn %s", urn ) );
-      }
-      return new ResponseEntity( pngBytes.get(), HttpStatus.OK );
+// TODO: Fix Model Diagram server crash issue for bugger Models
+//      final Try<byte[]>pngBytes = sdkHelper.generatePng( urn );
+//      if ( pngBytes.isFailure()  ) {
+//         throw new RuntimeException( String.format( "Failed to generate example payload for urn %s", urn ) );
+//      }
+//      return new ResponseEntity( pngBytes.get(), HttpStatus.OK );
+      return new ResponseEntity( HttpStatus.NOT_IMPLEMENTED );
    }
 
    @Override


### PR DESCRIPTION
## Description

Commented get model diagram API since this call crashing the server for bugger models.

Fixes

- Get model diagram API returns HTTP status code 501 - Not Implemented 