### PR TITLE
feat:License and copyright header information

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021-2022 T-Systems International GmbH
-    Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
+ Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+ See the NOTICE file(s) distributed with this work for additional
+ information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Apache License, Version 2.0 which is available at
-    https://www.apache.org/licenses/LICENSE-2.0.
+ This program and the accompanying materials are made available under the
+ terms of the Apache License, Version 2.0 which is available at
+ https://www.apache.org/licenses/LICENSE-2.0.
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-    License for the specific language governing permissions and limitations
-    under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
 
-    SPDX-License-Identifier: Apache-2.0
+ SPDX-License-Identifier: Apache-2.0
 -->
 <!-- Maven POM file to the SLDT services -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/AspectModelNotFoundException.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/AspectModelNotFoundException.java
@@ -1,7 +1,21 @@
-/*
- * Copyright (c) 2022 Bosch Software Innovations GmbH. All rights reserved.
- */
-
+/********************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 package org.eclipse.tractusx.semantics.hub;
 
 import org.eclipse.esmf.aspectmodel.urn.AspectModelUrn;

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/AspectModelService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/AspectModelService.java
@@ -1,7 +1,21 @@
-/*
- * Copyright (c) 2023 Bosch Software Innovations GmbH. All rights reserved.
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
- */
+/********************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 package org.eclipse.tractusx.semantics.hub;
 

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/ModelPackageNotFoundException.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/ModelPackageNotFoundException.java
@@ -1,6 +1,21 @@
-/*
- * Copyright (c) 2022 Bosch Software Innovations GmbH. All rights reserved.
- */
+/********************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 package org.eclipse.tractusx.semantics.hub;
 

--- a/backend/src/main/resources/catena-template.css
+++ b/backend/src/main/resources/catena-template.css
@@ -1,3 +1,21 @@
+/********************************************************************************
+ * Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 h1 {
     color: black;
     font-size: 2rem;

--- a/backend/src/main/resources/static/semantic-hub-openapi.yaml
+++ b/backend/src/main/resources/static/semantic-hub-openapi.yaml
@@ -1,3 +1,22 @@
+###############################################################
+# Copyright (c) 2021-2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
 openapi: 3.0.3
 info:
   title: Semantic Hub

--- a/charts/chart-testing-config.yaml
+++ b/charts/chart-testing-config.yaml
@@ -1,20 +1,22 @@
-# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
-
+###############################################################
+# Copyright (c) 2021-2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+#
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
-
+#
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
 # https://www.apache.org/licenses/LICENSE-2.0.
-
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-
+#
 # SPDX-License-Identifier: Apache-2.0
+###############################################################
 
 validate-maintainers: false
 chart-repos:

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2021-2022 T-Systems International GmbH
+ Copyright (c) 2021,2023 Contributors to the Eclipse Foundation
 
-    See the AUTHORS file(s) distributed with this work for additional
-    information regarding authorship.
+ See the NOTICE file(s) distributed with this work for additional
+ information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Apache License, Version 2.0 which is available at
-    https://www.apache.org/licenses/LICENSE-2.0.
+ This program and the accompanying materials are made available under the
+ terms of the Apache License, Version 2.0 which is available at
+ https://www.apache.org/licenses/LICENSE-2.0.
 
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-    License for the specific language governing permissions and limitations
-    under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License.
 
-    SPDX-License-Identifier: Apache-2.0
+ SPDX-License-Identifier: Apache-2.0
 -->
 
 <!-- Maven POM file to the SLDT packages -->


### PR DESCRIPTION
## Description
Added [License and copyright header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02/#description) information.