### PR TITLE
Fix typo in README.md

### DIFF
--- a/charts/semantic-hub/README.md
+++ b/charts/semantic-hub/README.md
@@ -19,7 +19,7 @@ This Helm charts installs the Semantic Hub application and its dependencies.
 ## Install
 ```
 kubectl create namespace semantics
-helm install hub -n semantics ./charts/semantic-hub`
+helm install hub -n semantics ./charts/semantic-hub
 ```
 
 ## Values


### PR DESCRIPTION
## Description
A backtick in the helm command leads to an error.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
