### PR TITLE
legal header information corrected

### DIFF
--- a/.github/actions/generate-dependencies-notice/action.yml
+++ b/.github/actions/generate-dependencies-notice/action.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/actions/generate-dependencies-notice/index.js
+++ b/.github/actions/generate-dependencies-notice/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/publish-image-semantic-hub.yml
+++ b/.github/workflows/publish-image-semantic-hub.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/charts/semantic-hub/Chart.yaml
+++ b/charts/semantic-hub/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-semantic-hub
 
 type: application
-version: 0.1.31
+version: 0.1.32
 appVersion: 0.2.14
 dependencies:
   - repository: https://charts.bitnami.com/bitnami

--- a/charts/semantic-hub/templates/graphdb/graphdb-deployment.yaml
+++ b/charts/semantic-hub/templates/graphdb/graphdb-deployment.yaml
@@ -1,24 +1,24 @@
-{{- if and (.Values.graphdb.enabled) (not .Values.hub.embeddedTripleStore) }}
 ###############################################################
 # Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-###############################################################
+  # Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  # License for the specific language governing permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  ###############################################################
 
+{{- if and (.Values.graphdb.enabled) (not .Values.hub.embeddedTripleStore) }}
 {{- $deployment_name := printf "cx-%s-graphdb" .Release.Name }}
 {{- $sec_name := printf "%s-sec" $deployment_name }}
 {{- $pvc_name := printf "%s-pvc" $deployment_name }}

--- a/charts/semantic-hub/templates/graphdb/graphdb-pvc.yaml
+++ b/charts/semantic-hub/templates/graphdb/graphdb-pvc.yaml
@@ -1,5 +1,4 @@
-{{- if and (.Values.graphdb.enabled) (not .Values.hub.embeddedTripleStore) }}
-  ###############################################################
+###############################################################
   # Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
   # Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
   #
@@ -19,6 +18,7 @@
   # SPDX-License-Identifier: Apache-2.0
   ###############################################################
 
+{{- if and (.Values.graphdb.enabled) (not .Values.hub.embeddedTripleStore) }}
 {{- $deployment_name := printf "cx-%s-graphdb" .Release.Name }}
 {{- $pvc_name := printf "%s-pvc" $deployment_name }}
 apiVersion: v1

--- a/charts/semantic-hub/templates/graphdb/graphdb-service.yaml
+++ b/charts/semantic-hub/templates/graphdb/graphdb-service.yaml
@@ -1,24 +1,24 @@
-{{- if and (.Values.graphdb.enabled) (not .Values.hub.embeddedTripleStore) }}
 ###############################################################
 # Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-###############################################################
+  # Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  # License for the specific language governing permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  ###############################################################
 
+{{- if and (.Values.graphdb.enabled) (not .Values.hub.embeddedTripleStore) }}
 {{- $deployment_name := printf "cx-%s-graphdb" .Release.Name }}
 {{- $service_name := printf "cx-%s-graphdb-svc" .Release.Name }}
 apiVersion: v1

--- a/charts/semantic-hub/templates/hub/hub-ingress.yaml
+++ b/charts/semantic-hub/templates/hub/hub-ingress.yaml
@@ -1,24 +1,24 @@
-{{- if .Values.hub.ingress.enabled }}
 ###############################################################
 # Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License, Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0.
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
-###############################################################
+  # Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+  #
+  # See the NOTICE file(s) distributed with this work for additional
+  # information regarding copyright ownership.
+  #
+  # This program and the accompanying materials are made available under the
+  # terms of the Apache License, Version 2.0 which is available at
+  # https://www.apache.org/licenses/LICENSE-2.0.
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  # License for the specific language governing permissions and limitations
+  # under the License.
+  #
+  # SPDX-License-Identifier: Apache-2.0
+  ###############################################################
 
+{{- if .Values.hub.ingress.enabled }}
 {{- $deployment_name := printf "cx-%s-hub" .Release.Name }}
 {{- $svc_name := printf "%s-svc" $deployment_name }}
 {{- $ingr_name := printf "%s-ingr" $deployment_name }}


### PR DESCRIPTION
## Description
Legal information header has been corrected:
- the legal information header will start at line 1 in each class
- double copyright expression like "Copyright (c) 2023 Copyright (c) 2023" have been corrected


