### PR TITLE
chore(build): bump default kind k8s node version

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -26,7 +26,7 @@ on:
       node_image:
         description: 'kindest/node image for k8s kind cluster'
         # k8s version from 3.1 release as default
-        default: 'kindest/node:v1.24.6'
+        default: 'kindest/node:v1.27.3'
         required: false
         type: string
 
@@ -41,6 +41,9 @@ jobs:
 
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v1
+        with:
+          # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
+          version: v0.20.0
 
       - name: Set up Helm
         uses: azure/setup-helm@v3


### PR DESCRIPTION
This PR bumps the default k8s version used for `kindest/node` to a recent one.
