### PR TITLE
chore(build): only skip ct install on PRs

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --charts charts/semantic-hub --config charts/chart-testing-config.yaml
-        if: steps.list-changed.outputs.changed == 'true'
+        if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
 
       - name: Run helm upgrade
         run: |


### PR DESCRIPTION
## Description

This change will let the `ct install` step execute for `workflow_dispatch` events.

fixes #193 
