### PR TITLE
fix:TRG 4.02 Using un-altered container base image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.2.15
 ### Added
+- Added helm upgrade feature into helm test
 - Removed the docker apk upgrade and update commands.
 
 ### Fixed
 =======
-- Added helm upgrade feature into helm test
 - Handled UrnSyntaxException.
 
 ## 0.2.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.15
+### Added
+- Removed the docker apk upgrade and update commands.
+
+### Fixed
+
 ## 0.2.14
 ### Added
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,11 +26,6 @@ RUN mvn package -DskipTests
 
 FROM eclipse-temurin:17-jre-alpine
 
-RUN apk --no-cache upgrade \
-    && apk --no-cache update \
-    && apk  --no-cache add graphviz \
-    && rm -rf /var/cache/apk/*
-
 RUN addgroup -g 101 -S spring \
     && adduser -u 100 -S spring -G spring \
     && mkdir -p /service \


### PR DESCRIPTION
## Description

fixes https://github.com/eclipse-tractusx/sldt-semantic-hub/issues/191 - Removed the docker apk upgrade and update commands. 