### PR TITLE
fix: Handle null SemanticModelStatus with 400 Bad Request in save and update APIs

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -107,7 +107,7 @@ public class TripleStorePersistence implements PersistenceLayer {
 
    @Override
    public SemanticModel updateModel( String urn, SemanticModelStatus status ) {
-	  validateStatusParameter(status);
+      validateStatusParameter(status);
       SemanticModel semanticModel = Optional.ofNullable( findByUrn(
             AspectModelUrn.fromUrn( urn ) ) ).orElseThrow( () -> new IllegalArgumentException(
             String.format( "Invalid URN %s",
@@ -128,7 +128,7 @@ public class TripleStorePersistence implements PersistenceLayer {
 
    @Override
    public SemanticModel save( SemanticModelType type, String newModel, SemanticModelStatus status ) {
-	  validateStatusParameter(status);
+      validateStatusParameter(status);
       final Model rdfModel = sdsSdk.load( newModel.getBytes( StandardCharsets.UTF_8 ) );
       final AspectModelUrn modelUrn = sdsSdk.getAspectUrn( rdfModel );
       Optional<ModelPackage> existsByPackage = findByPackageByUrn( ModelPackageUrn.fromUrn( modelUrn ) );

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -19,17 +19,7 @@
  ********************************************************************************/
 package org.eclipse.tractusx.semantics.hub.persistence.triplestore;
 
-import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nullable;
-
+import io.vavr.control.Try;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.query.Query;
@@ -56,331 +46,338 @@ import org.eclipse.tractusx.semantics.hub.model.SemanticModelStatus;
 import org.eclipse.tractusx.semantics.hub.model.SemanticModelType;
 import org.eclipse.tractusx.semantics.hub.persistence.PersistenceLayer;
 
-import io.vavr.control.Try;
+import javax.annotation.Nullable;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class TripleStorePersistence implements PersistenceLayer {
 
-   private final RDFConnectionRemoteBuilder rdfConnectionRemoteBuilder;
-   private final SdsSdk sdsSdk;
+	private final RDFConnectionRemoteBuilder rdfConnectionRemoteBuilder;
+	private final SdsSdk sdsSdk;
 
-   public TripleStorePersistence( final RDFConnectionRemoteBuilder rdfConnectionRemoteBuilder,
-         final SdsSdk sdsSdk ) {
-      this.rdfConnectionRemoteBuilder = rdfConnectionRemoteBuilder;
-      this.sdsSdk = sdsSdk;
-   }
+	public TripleStorePersistence(final RDFConnectionRemoteBuilder rdfConnectionRemoteBuilder,
+								  final SdsSdk sdsSdk) {
+		this.rdfConnectionRemoteBuilder = rdfConnectionRemoteBuilder;
+		this.sdsSdk = sdsSdk;
+	}
 
-   @Override
-   public SemanticModelList getModels( String namespaceFilter,
-         @Nullable ModelPackageStatus status, Integer page, Integer pageSize ) {
-      final Query query = SparqlQueries.buildFindAllQuery( namespaceFilter, status, page,
-            pageSize );
-      final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         rdfConnection.queryResultSet( query, resultSet -> {
-            final List<QuerySolution> querySolutions = ResultSetFormatter.toList( resultSet );
-            aspectModels.set( TripleStorePersistence.aspectModelFrom( querySolutions ) );
-         } );
-      }
-      int totalSemanticModelCount = getTotalItemsCount( namespaceFilter, status );
-      int totalPages = getTotalPages( totalSemanticModelCount, pageSize );
-      SemanticModelList modelList = new SemanticModelList();
-      List<SemanticModel> semanticModels = aspectModels.get();
-      modelList.setCurrentPage( page );
-      modelList.setItemCount( semanticModels.size() );
-      modelList.setTotalPages( totalPages );
-      modelList.setTotalItems( totalSemanticModelCount );
-      modelList.setItems( aspectModels.get() );
-      return modelList;
-   }
+	private static int getTotalPages(int totalItemsCount, int pageSize) {
+		if (totalItemsCount == 0 || pageSize == 0) {
+			return 0;
+		}
+		return (int) Math.ceil(((double) totalItemsCount) / (double) pageSize);
+	}
 
-   private static int getTotalPages( int totalItemsCount, int pageSize ) {
-      if ( totalItemsCount == 0 || pageSize == 0 ) {
-         return 0;
-      }
-      return (int) Math.ceil( ((double) totalItemsCount) / (double) pageSize );
-   }
+	private static List<SemanticModel> aspectModelFrom(
+		final List<QuerySolution> querySolutions) {
+		return querySolutions
+			.stream()
+			.map(TripleStorePersistence::aspectModelFrom)
+			.collect(Collectors.toList());
+	}
 
-   @Override
-   public SemanticModel getModel( final AspectModelUrn urn ) {
-      return findByUrn( urn );
-   }
+	private static SemanticModel aspectModelFrom(final QuerySolution querySolution) {
+		final String urn = querySolution.get(SparqlQueries.ASPECT).toString();
+		final String status = querySolution.get(SparqlQueries.STATUS_RESULT).toString();
+		AspectModelUrn aspectModelUrn = AspectModelUrn.fromUrn(urn);
+		SemanticModel model = new SemanticModel();
+		model.setUrn(aspectModelUrn.getUrn().toString());
+		model.setType(determineModelType(urn));
+		model.setVersion(aspectModelUrn.getVersion());
+		model.setName(aspectModelUrn.getName());
+		model.setStatus(SemanticModelStatus.fromValue(status));
+		return model;
+	}
 
-   @Override
-   public SemanticModel updateModel( String urn, SemanticModelStatus status ) {
+	private static SemanticModelType determineModelType(String aspectUrn) {
+		if (aspectUrn.contains("bamm")) {
+			return SemanticModelType.BAMM;
+		} else {
+			return SemanticModelType.SAMM;
+		}
+	}
 
-	  validateStatusParameter(status);
-      SemanticModel semanticModel = Optional.ofNullable( findByUrn(
-            AspectModelUrn.fromUrn( urn ) ) ).orElseThrow( () -> new IllegalArgumentException(
-            String.format( "Invalid URN %s",
-                  ModelPackageUrn.fromUrn( urn ).getUrn() ) ) );
-      ModelPackageStatus persistedModelStatus = ModelPackageStatus.valueOf(
-            semanticModel.getStatus().name() );
+	@Override
+	public SemanticModelList getModels(String namespaceFilter,
+									   @Nullable ModelPackageStatus status, Integer page, Integer pageSize) {
+		final Query query = SparqlQueries.buildFindAllQuery(namespaceFilter, status, page,
+			pageSize);
+		final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			rdfConnection.queryResultSet(query, resultSet -> {
+				final List<QuerySolution> querySolutions = ResultSetFormatter.toList(resultSet);
+				aspectModels.set(TripleStorePersistence.aspectModelFrom(querySolutions));
+			});
+		}
+		int totalSemanticModelCount = getTotalItemsCount(namespaceFilter, status);
+		int totalPages = getTotalPages(totalSemanticModelCount, pageSize);
+		SemanticModelList modelList = new SemanticModelList();
+		List<SemanticModel> semanticModels = aspectModels.get();
+		modelList.setCurrentPage(page);
+		modelList.setItemCount(semanticModels.size());
+		modelList.setTotalPages(totalPages);
+		modelList.setTotalItems(totalSemanticModelCount);
+		modelList.setItems(aspectModels.get());
+		return modelList;
+	}
 
-      final Model model = findContainingModelByUrn( urn );
+	@Override
+	public SemanticModel getModel(final AspectModelUrn urn) {
+		return findByUrn(urn);
+	}
 
-      final AspectModelUrn modelUrn = sdsSdk.getAspectUrn( model );
+	@Override
+	public SemanticModel updateModel(String urn, SemanticModelStatus status) {
 
-      validateStatus( status, model, modelUrn, persistedModelStatus );
+		validateStatusParameter(status);
+		SemanticModel semanticModel = Optional.ofNullable(findByUrn(
+			AspectModelUrn.fromUrn(urn))).orElseThrow(() -> new IllegalArgumentException(
+			String.format("Invalid URN %s",
+				ModelPackageUrn.fromUrn(urn).getUrn())));
+		ModelPackageStatus persistedModelStatus = ModelPackageStatus.valueOf(
+			semanticModel.getStatus().name());
 
-      updateModel( status, modelUrn, model );
+		final Model model = findContainingModelByUrn(urn);
 
-      return findByUrn( modelUrn );
-   }
+		final AspectModelUrn modelUrn = sdsSdk.getAspectUrn(model);
 
-   @Override
-   public SemanticModel save( SemanticModelType type, String newModel, SemanticModelStatus status ) {
-	  validateStatusParameter(status);
-      final Model rdfModel = sdsSdk.load( newModel.getBytes( StandardCharsets.UTF_8 ) );
-      final AspectModelUrn modelUrn = sdsSdk.getAspectUrn( rdfModel );
-      Optional<ModelPackage> existsByPackage = findByPackageByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
+		validateStatus(status, model, modelUrn, persistedModelStatus);
 
-      if ( existsByPackage.isPresent() ) {
-         validateStatus( status, rdfModel, modelUrn, existsByPackage.get().getStatus() );
-      }
+		updateModel(status, modelUrn, model);
 
-      sdsSdk.validate( rdfModel, this::findContainingModelByUrn, type );
+		return findByUrn(modelUrn);
+	}
 
-      Model rdfModelOriginal =  sdsSdk.load( newModel.getBytes( StandardCharsets.UTF_8 ) );
+	@Override
+	public SemanticModel save(SemanticModelType type, String newModel, SemanticModelStatus status) {
+		validateStatusParameter(status);
+		final Model rdfModel = sdsSdk.load(newModel.getBytes(StandardCharsets.UTF_8));
+		final AspectModelUrn modelUrn = sdsSdk.getAspectUrn(rdfModel);
+		Optional<ModelPackage> existsByPackage = findByPackageByUrn(ModelPackageUrn.fromUrn(modelUrn));
 
-      updateModel( status, modelUrn, rdfModelOriginal );
+		if (existsByPackage.isPresent()) {
+			validateStatus(status, rdfModel, modelUrn, existsByPackage.get().getStatus());
+		}
 
-      return findByUrn( modelUrn );
-   }
+		sdsSdk.validate(rdfModel, this::findContainingModelByUrn, type);
 
-   private void updateModel( SemanticModelStatus status, AspectModelUrn modelUrn, Model rdfModelOriginal ) {
-      final Resource rootResource = ResourceFactory.createResource( modelUrn.getUrnPrefix() );
-      rdfModelOriginal.add( rootResource, SparqlQueries.STATUS_PROPERTY,
-            ModelPackageStatus.valueOf( status.name() ).toString() );
+		Model rdfModelOriginal = sdsSdk.load(newModel.getBytes(StandardCharsets.UTF_8));
 
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         rdfConnection.update( new UpdateBuilder().addInsert( rdfModelOriginal ).build() );
-      }
-   }
+		updateModel(status, modelUrn, rdfModelOriginal);
 
+		return findByUrn(modelUrn);
+	}
 
-   private void validateStatus( SemanticModelStatus status, Model rdfModel, AspectModelUrn modelUrn, ModelPackageStatus persistedModelStatus ) {
-      final ModelPackageStatus desiredModelStatus = ModelPackageStatus.valueOf( status.name() );
-      switch ( persistedModelStatus ) {
-      case DRAFT:
-         if ( desiredModelStatus.equals( ModelPackageStatus.RELEASED ) && !hasReferenceToDraftPackage( modelUrn, rdfModel ) ) {
-            throw new InvalidStateTransitionException( "It is not allowed to release an aspect that has dependencies in DRAFT state." );
-         } else if ( desiredModelStatus.equals( ModelPackageStatus.STANDARDIZED ) ) {
-            throw new IllegalArgumentException(
-                  String.format( "The package %s is in status %s. Only a transition to RELEASED or DEPRECATED is possible.",
-                        ModelPackageUrn.fromUrn( modelUrn ).getUrn(), persistedModelStatus.name() ) );
-         }
-         deleteByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
-         break;
-      case RELEASED:
-         // released models can only be updated when the new state is deprecated or standardized
-         if ( desiredModelStatus.equals( ModelPackageStatus.DEPRECATED ) || desiredModelStatus.equals( ModelPackageStatus.STANDARDIZED ) ) {
-            deleteByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
-         } else {
-            throw new IllegalArgumentException(
-                  String.format( "The package %s is already in status %s and cannot be modified. Only a transition to STANDARDIZED or DEPRECATED is possible.",
-                        ModelPackageUrn.fromUrn( modelUrn ).getUrn(), persistedModelStatus.name() ) );
-         }
-         break;
-      case STANDARDIZED:
-         if ( desiredModelStatus.equals( ModelPackageStatus.DEPRECATED ) ) {
-            deleteByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
-         } else {
-            throw new IllegalArgumentException(
-                  String.format( "The package %s is already in status %s and cannot be modified. Only a transition to DEPRECATED is possible.",
-                        ModelPackageUrn.fromUrn( modelUrn ).getUrn(), persistedModelStatus.name() ) );
-         }
-         break;
-      case DEPRECATED:
-         throw new IllegalArgumentException(
-               String.format( "The package %s is already in status %s and cannot be modified.",
-                     ModelPackageUrn.fromUrn( modelUrn ).getUrn(), persistedModelStatus.name() ) );
-      }
-   }
+	private void updateModel(SemanticModelStatus status, AspectModelUrn modelUrn, Model rdfModelOriginal) {
+		final Resource rootResource = ResourceFactory.createResource(modelUrn.getUrnPrefix());
+		rdfModelOriginal.add(rootResource, SparqlQueries.STATUS_PROPERTY,
+			ModelPackageStatus.valueOf(status.name()).toString());
 
-   @Override
-   public String getModelDefinition( final AspectModelUrn urn ) {
-      Model jenaModelByUrn = findJenaModelByUrn( urn );
-      if ( jenaModelByUrn == null ) {
-         throw new AspectModelNotFoundException( urn );
-      }
-      StringWriter out = new StringWriter();
-      jenaModelByUrn.write( out, "TURTLE" );
-      return out.toString();
-   }
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			rdfConnection.update(new UpdateBuilder().addInsert(rdfModelOriginal).build());
+		}
+	}
 
-   @Override
-   public void deleteModelsPackage( final ModelPackageUrn urn ) {
-      ModelPackage modelsPackage = findByPackageByUrn( urn )
-            .orElseThrow( () -> new ModelPackageNotFoundException( urn ) );
+	private void validateStatus(SemanticModelStatus status, Model rdfModel, AspectModelUrn modelUrn, ModelPackageStatus persistedModelStatus) {
+		final ModelPackageStatus desiredModelStatus = ModelPackageStatus.valueOf(status.name());
+		switch (persistedModelStatus) {
+			case DRAFT:
+				if (desiredModelStatus.equals(ModelPackageStatus.RELEASED) && !hasReferenceToDraftPackage(modelUrn, rdfModel)) {
+					throw new InvalidStateTransitionException("It is not allowed to release an aspect that has dependencies in DRAFT state.");
+				} else if (desiredModelStatus.equals(ModelPackageStatus.STANDARDIZED)) {
+					throw new IllegalArgumentException(
+						String.format("The package %s is in status %s. Only a transition to RELEASED or DEPRECATED is possible.",
+							ModelPackageUrn.fromUrn(modelUrn).getUrn(), persistedModelStatus.name()));
+				}
+				deleteByUrn(ModelPackageUrn.fromUrn(modelUrn));
+				break;
+			case RELEASED:
+				// released models can only be updated when the new state is deprecated or standardized
+				if (desiredModelStatus.equals(ModelPackageStatus.DEPRECATED) || desiredModelStatus.equals(ModelPackageStatus.STANDARDIZED)) {
+					deleteByUrn(ModelPackageUrn.fromUrn(modelUrn));
+				} else {
+					throw new IllegalArgumentException(
+						String.format("The package %s is already in status %s and cannot be modified. Only a transition to STANDARDIZED or DEPRECATED is possible.",
+							ModelPackageUrn.fromUrn(modelUrn).getUrn(), persistedModelStatus.name()));
+				}
+				break;
+			case STANDARDIZED:
+				if (desiredModelStatus.equals(ModelPackageStatus.DEPRECATED)) {
+					deleteByUrn(ModelPackageUrn.fromUrn(modelUrn));
+				} else {
+					throw new IllegalArgumentException(
+						String.format("The package %s is already in status %s and cannot be modified. Only a transition to DEPRECATED is possible.",
+							ModelPackageUrn.fromUrn(modelUrn).getUrn(), persistedModelStatus.name()));
+				}
+				break;
+			case DEPRECATED:
+				throw new IllegalArgumentException(
+					String.format("The package %s is already in status %s and cannot be modified.",
+						ModelPackageUrn.fromUrn(modelUrn).getUrn(), persistedModelStatus.name()));
+		}
+	}
 
-      ModelPackageStatus status = modelsPackage.getStatus();
-      if ( ModelPackageStatus.RELEASED.equals( status ) || ModelPackageStatus.STANDARDIZED.equals( status ) ) {
-         throw new IllegalArgumentException(
-               String.format( "The package %s is already in status %s and cannot be deleted.",
-                     urn.getUrn(), status.name() ) );
-      }
-      deleteByUrn( urn );
-   }
+	@Override
+	public String getModelDefinition(final AspectModelUrn urn) {
+		Model jenaModelByUrn = findJenaModelByUrn(urn);
+		if (jenaModelByUrn == null) {
+			throw new AspectModelNotFoundException(urn);
+		}
+		StringWriter out = new StringWriter();
+		jenaModelByUrn.write(out, "TURTLE");
+		return out.toString();
+	}
 
-   @Override
-   public SemanticModelList findModelListByUrns( List<AspectModelUrn> urns, int page, int pageSize ) {
-      final Query query = SparqlQueries.buildFindListByUrns( urns, page, pageSize );
-      final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         rdfConnection.queryResultSet( query, resultSet -> {
-            final List<QuerySolution> querySolutions = ResultSetFormatter.toList( resultSet );
-            aspectModels.set( TripleStorePersistence.aspectModelFrom( querySolutions ) );
-         } );
-      }
-      int totalSemanticModelCount = getSelectiveItemsCount( null, null, null, null, urns );
-      int totalPages = getTotalPages( totalSemanticModelCount, pageSize );
-      SemanticModelList modelList = new SemanticModelList();
-      List<SemanticModel> semanticModels = aspectModels.get();
-      modelList.setCurrentPage( page );
-      modelList.setItemCount( semanticModels.size() );
-      modelList.setTotalPages( totalPages );
-      modelList.setTotalItems( totalSemanticModelCount );
-      modelList.setItems( aspectModels.get() );
-      return modelList;
-   }
+	@Override
+	public void deleteModelsPackage(final ModelPackageUrn urn) {
+		ModelPackage modelsPackage = findByPackageByUrn(urn)
+			.orElseThrow(() -> new ModelPackageNotFoundException(urn));
 
-   public boolean echo() {
-      final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build();
+		ModelPackageStatus status = modelsPackage.getStatus();
+		if (ModelPackageStatus.RELEASED.equals(status) || ModelPackageStatus.STANDARDIZED.equals(status)) {
+			throw new IllegalArgumentException(
+				String.format("The package %s is already in status %s and cannot be deleted.",
+					urn.getUrn(), status.name()));
+		}
+		deleteByUrn(urn);
+	}
 
-      return rdfConnection.queryAsk( SparqlQueries.echoQuery() );
-   }
+	@Override
+	public SemanticModelList findModelListByUrns(List<AspectModelUrn> urns, int page, int pageSize) {
+		final Query query = SparqlQueries.buildFindListByUrns(urns, page, pageSize);
+		final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			rdfConnection.queryResultSet(query, resultSet -> {
+				final List<QuerySolution> querySolutions = ResultSetFormatter.toList(resultSet);
+				aspectModels.set(TripleStorePersistence.aspectModelFrom(querySolutions));
+			});
+		}
+		int totalSemanticModelCount = getSelectiveItemsCount(null, null, null, null, urns);
+		int totalPages = getTotalPages(totalSemanticModelCount, pageSize);
+		SemanticModelList modelList = new SemanticModelList();
+		List<SemanticModel> semanticModels = aspectModels.get();
+		modelList.setCurrentPage(page);
+		modelList.setItemCount(semanticModels.size());
+		modelList.setTotalPages(totalPages);
+		modelList.setTotalItems(totalSemanticModelCount);
+		modelList.setItems(aspectModels.get());
+		return modelList;
+	}
 
-   private boolean hasReferenceToDraftPackage( AspectModelUrn modelUrn, Model model ) {
-      Pattern pattern = Pattern.compile( SparqlQueries.ALL_SAMM_ASPECT_URN_PREFIX );
+	public boolean echo() {
+		final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build();
 
-      List<String> urns = AspectModelResolver.getAllUrnsInModel( model ).stream().filter( urn -> getAspectModelUrn( urn ).isSuccess() )
-            .map( urn -> getAspectModelUrn( urn ).get().getUrnPrefix() )
-            .distinct()
-            .collect( Collectors.toList() );
+		return rdfConnection.queryAsk(SparqlQueries.echoQuery());
+	}
 
-      for ( var entry : urns ) {
-         Matcher matcher = pattern.matcher( entry );
-         if ( !matcher.find() && !modelUrn.getUrnPrefix().equals( entry ) ) {
-            if ( findByPackageByUrn( ModelPackageUrn.fromUrn( entry ) ).get().getStatus().equals( ModelPackageStatus.DRAFT ) ) {
-               return false;
-            }
-         }
-      }
+	private boolean hasReferenceToDraftPackage(AspectModelUrn modelUrn, Model model) {
+		Pattern pattern = Pattern.compile(SparqlQueries.ALL_SAMM_ASPECT_URN_PREFIX);
 
-      return true;
-   }
+		List<String> urns = AspectModelResolver.getAllUrnsInModel(model).stream().filter(urn -> getAspectModelUrn(urn).isSuccess())
+			.map(urn -> getAspectModelUrn(urn).get().getUrnPrefix())
+			.distinct()
+			.collect(Collectors.toList());
 
-   private Integer getTotalItemsCount( @Nullable String namespaceFilter,
-         @Nullable ModelPackageStatus status ) {
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         AtomicReference<Integer> count = new AtomicReference<>();
-         rdfConnection.querySelect(
-               SparqlQueries.buildCountAspectModelsQuery( namespaceFilter, status ),
-               querySolution -> {
-                  int countResult = querySolution.getLiteral( "aspectModelCount" ).getInt();
-                  count.set( countResult );
-               } );
-         return count.get();
-      }
-   }
+		for (var entry : urns) {
+			Matcher matcher = pattern.matcher(entry);
+			if (!matcher.find() && !modelUrn.getUrnPrefix().equals(entry)) {
+				if (findByPackageByUrn(ModelPackageUrn.fromUrn(entry)).get().getStatus().equals(ModelPackageStatus.DRAFT)) {
+					return false;
+				}
+			}
+		}
 
-   private Integer getSelectiveItemsCount( @Nullable String namespaceFilter, @Nullable String nameFilter,
-         @Nullable String nameType,
-         @Nullable ModelPackageStatus status, List<AspectModelUrn> urns ) {
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         AtomicReference<Integer> count = new AtomicReference<>();
-         rdfConnection.querySelect(
-               SparqlQueries.buildCountSelectiveAspectModelsQuery( namespaceFilter, nameFilter, nameType, status, urns ),
-               querySolution -> {
-                  int countResult = querySolution.getLiteral( "aspectModelCount" ).getInt();
-                  count.set( countResult );
-               } );
-         return count.get();
-      }
-   }
+		return true;
+	}
 
-   private void deleteByUrn( final ModelPackageUrn modelsPackage ) {
-      final UpdateRequest deleteByUrn = SparqlQueries.buildDeleteByUrnRequest( modelsPackage );
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         rdfConnection.update( deleteByUrn );
-      }
-   }
+	private Integer getTotalItemsCount(@Nullable String namespaceFilter,
+									   @Nullable ModelPackageStatus status) {
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			AtomicReference<Integer> count = new AtomicReference<>();
+			rdfConnection.querySelect(
+				SparqlQueries.buildCountAspectModelsQuery(namespaceFilter, status),
+				querySolution -> {
+					int countResult = querySolution.getLiteral("aspectModelCount").getInt();
+					count.set(countResult);
+				});
+			return count.get();
+		}
+	}
 
-   private Model findContainingModelByUrn( final String urn ) {
-      final Query query = SparqlQueries.buildFindModelElementClosureQuery( urn );
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         return rdfConnection.queryConstruct( query );
-      }
-   }
+	private Integer getSelectiveItemsCount(@Nullable String namespaceFilter, @Nullable String nameFilter,
+										   @Nullable String nameType,
+										   @Nullable ModelPackageStatus status, List<AspectModelUrn> urns) {
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			AtomicReference<Integer> count = new AtomicReference<>();
+			rdfConnection.querySelect(
+				SparqlQueries.buildCountSelectiveAspectModelsQuery(namespaceFilter, nameFilter, nameType, status, urns),
+				querySolution -> {
+					int countResult = querySolution.getLiteral("aspectModelCount").getInt();
+					count.set(countResult);
+				});
+			return count.get();
+		}
+	}
 
-   private Optional<ModelPackage> findByPackageByUrn( ModelPackageUrn modelsPackage ) {
-      final Query query = SparqlQueries.buildFindByPackageQuery( modelsPackage );
-      final AtomicReference<String> aspectModel = new AtomicReference<>();
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         rdfConnection.querySelect( query,
-               result -> aspectModel.set( result.get( SparqlQueries.STATUS_RESULT ).toString() ) );
-      }
-      if ( aspectModel.get() != null ) {
-         return Optional.of( new ModelPackage( ModelPackageStatus.valueOf( aspectModel.get() ) ) );
-      }
-      return Optional.empty();
-   }
+	private void deleteByUrn(final ModelPackageUrn modelsPackage) {
+		final UpdateRequest deleteByUrn = SparqlQueries.buildDeleteByUrnRequest(modelsPackage);
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			rdfConnection.update(deleteByUrn);
+		}
+	}
 
-   private SemanticModel findByUrn( final AspectModelUrn urn ) {
-      final Query query = SparqlQueries.buildFindByUrnQuery( urn );
-      final AtomicReference<SemanticModel> aspectModel = new AtomicReference<>();
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         rdfConnection.querySelect( query,
-               result -> aspectModel.set( TripleStorePersistence.aspectModelFrom( result ) ) );
-      }
-      return aspectModel.get();
-   }
+	private Model findContainingModelByUrn(final String urn) {
+		final Query query = SparqlQueries.buildFindModelElementClosureQuery(urn);
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			return rdfConnection.queryConstruct(query);
+		}
+	}
 
-   private Model findJenaModelByUrn( final AspectModelUrn urn ) {
-      final Query constructQuery = SparqlQueries.buildFindByUrnConstructQuery( urn );
-      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
-         return rdfConnection.queryConstruct( constructQuery );
-      }
-   }
+	private Optional<ModelPackage> findByPackageByUrn(ModelPackageUrn modelsPackage) {
+		final Query query = SparqlQueries.buildFindByPackageQuery(modelsPackage);
+		final AtomicReference<String> aspectModel = new AtomicReference<>();
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			rdfConnection.querySelect(query,
+				result -> aspectModel.set(result.get(SparqlQueries.STATUS_RESULT).toString()));
+		}
+		if (aspectModel.get() != null) {
+			return Optional.of(new ModelPackage(ModelPackageStatus.valueOf(aspectModel.get())));
+		}
+		return Optional.empty();
+	}
 
-   private Try<AspectModelUrn> getAspectModelUrn( String urn ) {
-      try {
-         return Try.success( AspectModelUrn.fromUrn( urn ) );
-      } catch ( UrnSyntaxException var2 ) {
-         return Try.failure( var2 );
-      }
-   }
+	private SemanticModel findByUrn(final AspectModelUrn urn) {
+		final Query query = SparqlQueries.buildFindByUrnQuery(urn);
+		final AtomicReference<SemanticModel> aspectModel = new AtomicReference<>();
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			rdfConnection.querySelect(query,
+				result -> aspectModel.set(TripleStorePersistence.aspectModelFrom(result)));
+		}
+		return aspectModel.get();
+	}
 
-   private static List<SemanticModel> aspectModelFrom(
-         final List<QuerySolution> querySolutions ) {
-      return querySolutions
-            .stream()
-            .map( TripleStorePersistence::aspectModelFrom )
-            .collect( Collectors.toList() );
-   }
+	private Model findJenaModelByUrn(final AspectModelUrn urn) {
+		final Query constructQuery = SparqlQueries.buildFindByUrnConstructQuery(urn);
+		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
+			return rdfConnection.queryConstruct(constructQuery);
+		}
+	}
 
-   private static SemanticModel aspectModelFrom( final QuerySolution querySolution ) {
-      final String urn = querySolution.get( SparqlQueries.ASPECT ).toString();
-      final String status = querySolution.get( SparqlQueries.STATUS_RESULT ).toString();
-      AspectModelUrn aspectModelUrn = AspectModelUrn.fromUrn( urn );
-      SemanticModel model = new SemanticModel();
-      model.setUrn( aspectModelUrn.getUrn().toString() );
-      model.setType( determineModelType(urn) );
-      model.setVersion( aspectModelUrn.getVersion() );
-      model.setName( aspectModelUrn.getName() );
-      model.setStatus( SemanticModelStatus.fromValue( status ) );
-      return model;
-   }
+	private Try<AspectModelUrn> getAspectModelUrn(String urn) {
+		try {
+			return Try.success(AspectModelUrn.fromUrn(urn));
+		} catch (UrnSyntaxException var2) {
+			return Try.failure(var2);
+		}
+	}
 
-   private static SemanticModelType determineModelType(String aspectUrn){
-      if(aspectUrn.contains( "bamm" )){
-         return SemanticModelType.BAMM;
-      }else{
-         return SemanticModelType.SAMM;
-      }
-   }
-
-   private void validateStatusParameter(SemanticModelStatus status) {
+	private void validateStatusParameter(SemanticModelStatus status) {
 		if (ObjectUtils.allNull(status)) {
 			throw new IllegalArgumentException(
 				"SemanticModelStatus cannot be null. Valid values are: DRAFT, RELEASED, STANDARDIZED, DEPRECATED.");

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -379,7 +379,8 @@ public class TripleStorePersistence implements PersistenceLayer {
          return SemanticModelType.SAMM;
       }
    }
-	private void validateStatusParameter(SemanticModelStatus status) {
+
+   private void validateStatusParameter(SemanticModelStatus status) {
 		if (ObjectUtils.allNull(status)) {
 			throw new IllegalArgumentException(
 				"SemanticModelStatus cannot be null. Valid values are: DRAFT, RELEASED, STANDARDIZED, DEPRECATED.");

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -107,8 +107,7 @@ public class TripleStorePersistence implements PersistenceLayer {
 
    @Override
    public SemanticModel updateModel( String urn, SemanticModelStatus status ) {
-
-	   validateStatusParameter(status);
+	  validateStatusParameter(status);
       SemanticModel semanticModel = Optional.ofNullable( findByUrn(
             AspectModelUrn.fromUrn( urn ) ) ).orElseThrow( () -> new IllegalArgumentException(
             String.format( "Invalid URN %s",

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -19,7 +19,17 @@
  ********************************************************************************/
 package org.eclipse.tractusx.semantics.hub.persistence.triplestore;
 
-import io.vavr.control.Try;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.query.Query;
@@ -46,337 +56,329 @@ import org.eclipse.tractusx.semantics.hub.model.SemanticModelStatus;
 import org.eclipse.tractusx.semantics.hub.model.SemanticModelType;
 import org.eclipse.tractusx.semantics.hub.persistence.PersistenceLayer;
 
-import javax.annotation.Nullable;
-import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import io.vavr.control.Try;
 
 public class TripleStorePersistence implements PersistenceLayer {
 
-	private final RDFConnectionRemoteBuilder rdfConnectionRemoteBuilder;
-	private final SdsSdk sdsSdk;
+   private final RDFConnectionRemoteBuilder rdfConnectionRemoteBuilder;
+   private final SdsSdk sdsSdk;
 
-	public TripleStorePersistence(final RDFConnectionRemoteBuilder rdfConnectionRemoteBuilder,
-								  final SdsSdk sdsSdk) {
-		this.rdfConnectionRemoteBuilder = rdfConnectionRemoteBuilder;
-		this.sdsSdk = sdsSdk;
-	}
+   public TripleStorePersistence( final RDFConnectionRemoteBuilder rdfConnectionRemoteBuilder,
+         final SdsSdk sdsSdk ) {
+      this.rdfConnectionRemoteBuilder = rdfConnectionRemoteBuilder;
+      this.sdsSdk = sdsSdk;
+   }
 
-	private static int getTotalPages(int totalItemsCount, int pageSize) {
-		if (totalItemsCount == 0 || pageSize == 0) {
-			return 0;
-		}
-		return (int) Math.ceil(((double) totalItemsCount) / (double) pageSize);
-	}
+   @Override
+   public SemanticModelList getModels( String namespaceFilter,
+         @Nullable ModelPackageStatus status, Integer page, Integer pageSize ) {
+      final Query query = SparqlQueries.buildFindAllQuery( namespaceFilter, status, page,
+            pageSize );
+      final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         rdfConnection.queryResultSet( query, resultSet -> {
+            final List<QuerySolution> querySolutions = ResultSetFormatter.toList( resultSet );
+            aspectModels.set( TripleStorePersistence.aspectModelFrom( querySolutions ) );
+         } );
+      }
+      int totalSemanticModelCount = getTotalItemsCount( namespaceFilter, status );
+      int totalPages = getTotalPages( totalSemanticModelCount, pageSize );
+      SemanticModelList modelList = new SemanticModelList();
+      List<SemanticModel> semanticModels = aspectModels.get();
+      modelList.setCurrentPage( page );
+      modelList.setItemCount( semanticModels.size() );
+      modelList.setTotalPages( totalPages );
+      modelList.setTotalItems( totalSemanticModelCount );
+      modelList.setItems( aspectModels.get() );
+      return modelList;
+   }
 
-	private static List<SemanticModel> aspectModelFrom(
-		final List<QuerySolution> querySolutions) {
-		return querySolutions
-			.stream()
-			.map(TripleStorePersistence::aspectModelFrom)
-			.collect(Collectors.toList());
-	}
+   private static int getTotalPages( int totalItemsCount, int pageSize ) {
+      if ( totalItemsCount == 0 || pageSize == 0 ) {
+         return 0;
+      }
+      return (int) Math.ceil( ((double) totalItemsCount) / (double) pageSize );
+   }
 
-	private static SemanticModel aspectModelFrom(final QuerySolution querySolution) {
-		final String urn = querySolution.get(SparqlQueries.ASPECT).toString();
-		final String status = querySolution.get(SparqlQueries.STATUS_RESULT).toString();
-		AspectModelUrn aspectModelUrn = AspectModelUrn.fromUrn(urn);
-		SemanticModel model = new SemanticModel();
-		model.setUrn(aspectModelUrn.getUrn().toString());
-		model.setType(determineModelType(urn));
-		model.setVersion(aspectModelUrn.getVersion());
-		model.setName(aspectModelUrn.getName());
-		model.setStatus(SemanticModelStatus.fromValue(status));
-		return model;
-	}
+   @Override
+   public SemanticModel getModel( final AspectModelUrn urn ) {
+      return findByUrn( urn );
+   }
 
-	private static SemanticModelType determineModelType(String aspectUrn) {
-		if (aspectUrn.contains("bamm")) {
-			return SemanticModelType.BAMM;
-		} else {
-			return SemanticModelType.SAMM;
-		}
-	}
+   @Override
+   public SemanticModel updateModel( String urn, SemanticModelStatus status ) {
 
-	@Override
-	public SemanticModelList getModels(String namespaceFilter,
-									   @Nullable ModelPackageStatus status, Integer page, Integer pageSize) {
-		final Query query = SparqlQueries.buildFindAllQuery(namespaceFilter, status, page,
-			pageSize);
-		final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			rdfConnection.queryResultSet(query, resultSet -> {
-				final List<QuerySolution> querySolutions = ResultSetFormatter.toList(resultSet);
-				aspectModels.set(TripleStorePersistence.aspectModelFrom(querySolutions));
-			});
-		}
-		int totalSemanticModelCount = getTotalItemsCount(namespaceFilter, status);
-		int totalPages = getTotalPages(totalSemanticModelCount, pageSize);
-		SemanticModelList modelList = new SemanticModelList();
-		List<SemanticModel> semanticModels = aspectModels.get();
-		modelList.setCurrentPage(page);
-		modelList.setItemCount(semanticModels.size());
-		modelList.setTotalPages(totalPages);
-		modelList.setTotalItems(totalSemanticModelCount);
-		modelList.setItems(aspectModels.get());
-		return modelList;
-	}
+	   validateStatusParameter(status);
+      SemanticModel semanticModel = Optional.ofNullable( findByUrn(
+            AspectModelUrn.fromUrn( urn ) ) ).orElseThrow( () -> new IllegalArgumentException(
+            String.format( "Invalid URN %s",
+                  ModelPackageUrn.fromUrn( urn ).getUrn() ) ) );
+      ModelPackageStatus persistedModelStatus = ModelPackageStatus.valueOf(
+            semanticModel.getStatus().name() );
 
-	@Override
-	public SemanticModel getModel(final AspectModelUrn urn) {
-		return findByUrn(urn);
-	}
+      final Model model = findContainingModelByUrn( urn );
 
-	@Override
-	public SemanticModel updateModel(String urn, SemanticModelStatus status) {
+      final AspectModelUrn modelUrn = sdsSdk.getAspectUrn( model );
 
-		validateStatusParameter(status);
-		SemanticModel semanticModel = Optional.ofNullable(findByUrn(
-			AspectModelUrn.fromUrn(urn))).orElseThrow(() -> new IllegalArgumentException(
-			String.format("Invalid URN %s",
-				ModelPackageUrn.fromUrn(urn).getUrn())));
-		ModelPackageStatus persistedModelStatus = ModelPackageStatus.valueOf(
-			semanticModel.getStatus().name());
+      validateStatus( status, model, modelUrn, persistedModelStatus );
 
-		final Model model = findContainingModelByUrn(urn);
+      updateModel( status, modelUrn, model );
 
-		final AspectModelUrn modelUrn = sdsSdk.getAspectUrn(model);
+      return findByUrn( modelUrn );
+   }
 
-		validateStatus(status, model, modelUrn, persistedModelStatus);
+   @Override
+   public SemanticModel save( SemanticModelType type, String newModel, SemanticModelStatus status ) {
+	  validateStatusParameter(status);
+      final Model rdfModel = sdsSdk.load( newModel.getBytes( StandardCharsets.UTF_8 ) );
+      final AspectModelUrn modelUrn = sdsSdk.getAspectUrn( rdfModel );
+      Optional<ModelPackage> existsByPackage = findByPackageByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
 
-		updateModel(status, modelUrn, model);
+      if ( existsByPackage.isPresent() ) {
+         validateStatus( status, rdfModel, modelUrn, existsByPackage.get().getStatus() );
+      }
 
-		return findByUrn(modelUrn);
-	}
+      sdsSdk.validate( rdfModel, this::findContainingModelByUrn, type );
 
-	@Override
-	public SemanticModel save(SemanticModelType type, String newModel, SemanticModelStatus status) {
-		validateStatusParameter(status);
-		final Model rdfModel = sdsSdk.load(newModel.getBytes(StandardCharsets.UTF_8));
-		final AspectModelUrn modelUrn = sdsSdk.getAspectUrn(rdfModel);
-		Optional<ModelPackage> existsByPackage = findByPackageByUrn(ModelPackageUrn.fromUrn(modelUrn));
+      Model rdfModelOriginal =  sdsSdk.load( newModel.getBytes( StandardCharsets.UTF_8 ) );
 
-		if (existsByPackage.isPresent()) {
-			validateStatus(status, rdfModel, modelUrn, existsByPackage.get().getStatus());
-		}
+      updateModel( status, modelUrn, rdfModelOriginal );
 
-		sdsSdk.validate(rdfModel, this::findContainingModelByUrn, type);
+      return findByUrn( modelUrn );
+   }
 
-		Model rdfModelOriginal = sdsSdk.load(newModel.getBytes(StandardCharsets.UTF_8));
+   private void updateModel( SemanticModelStatus status, AspectModelUrn modelUrn, Model rdfModelOriginal ) {
+      final Resource rootResource = ResourceFactory.createResource( modelUrn.getUrnPrefix() );
+      rdfModelOriginal.add( rootResource, SparqlQueries.STATUS_PROPERTY,
+            ModelPackageStatus.valueOf( status.name() ).toString() );
 
-		updateModel(status, modelUrn, rdfModelOriginal);
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         rdfConnection.update( new UpdateBuilder().addInsert( rdfModelOriginal ).build() );
+      }
+   }
 
-		return findByUrn(modelUrn);
-	}
 
-	private void updateModel(SemanticModelStatus status, AspectModelUrn modelUrn, Model rdfModelOriginal) {
-		final Resource rootResource = ResourceFactory.createResource(modelUrn.getUrnPrefix());
-		rdfModelOriginal.add(rootResource, SparqlQueries.STATUS_PROPERTY,
-			ModelPackageStatus.valueOf(status.name()).toString());
+   private void validateStatus( SemanticModelStatus status, Model rdfModel, AspectModelUrn modelUrn, ModelPackageStatus persistedModelStatus ) {
+      final ModelPackageStatus desiredModelStatus = ModelPackageStatus.valueOf( status.name() );
+      switch ( persistedModelStatus ) {
+      case DRAFT:
+         if ( desiredModelStatus.equals( ModelPackageStatus.RELEASED ) && !hasReferenceToDraftPackage( modelUrn, rdfModel ) ) {
+            throw new InvalidStateTransitionException( "It is not allowed to release an aspect that has dependencies in DRAFT state." );
+         } else if ( desiredModelStatus.equals( ModelPackageStatus.STANDARDIZED ) ) {
+            throw new IllegalArgumentException(
+                  String.format( "The package %s is in status %s. Only a transition to RELEASED or DEPRECATED is possible.",
+                        ModelPackageUrn.fromUrn( modelUrn ).getUrn(), persistedModelStatus.name() ) );
+         }
+         deleteByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
+         break;
+      case RELEASED:
+         // released models can only be updated when the new state is deprecated or standardized
+         if ( desiredModelStatus.equals( ModelPackageStatus.DEPRECATED ) || desiredModelStatus.equals( ModelPackageStatus.STANDARDIZED ) ) {
+            deleteByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
+         } else {
+            throw new IllegalArgumentException(
+                  String.format( "The package %s is already in status %s and cannot be modified. Only a transition to STANDARDIZED or DEPRECATED is possible.",
+                        ModelPackageUrn.fromUrn( modelUrn ).getUrn(), persistedModelStatus.name() ) );
+         }
+         break;
+      case STANDARDIZED:
+         if ( desiredModelStatus.equals( ModelPackageStatus.DEPRECATED ) ) {
+            deleteByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
+         } else {
+            throw new IllegalArgumentException(
+                  String.format( "The package %s is already in status %s and cannot be modified. Only a transition to DEPRECATED is possible.",
+                        ModelPackageUrn.fromUrn( modelUrn ).getUrn(), persistedModelStatus.name() ) );
+         }
+         break;
+      case DEPRECATED:
+         throw new IllegalArgumentException(
+               String.format( "The package %s is already in status %s and cannot be modified.",
+                     ModelPackageUrn.fromUrn( modelUrn ).getUrn(), persistedModelStatus.name() ) );
+      }
+   }
 
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			rdfConnection.update(new UpdateBuilder().addInsert(rdfModelOriginal).build());
-		}
-	}
+   @Override
+   public String getModelDefinition( final AspectModelUrn urn ) {
+      Model jenaModelByUrn = findJenaModelByUrn( urn );
+      if ( jenaModelByUrn == null ) {
+         throw new AspectModelNotFoundException( urn );
+      }
+      StringWriter out = new StringWriter();
+      jenaModelByUrn.write( out, "TURTLE" );
+      return out.toString();
+   }
 
-	private void validateStatus(SemanticModelStatus status, Model rdfModel, AspectModelUrn modelUrn, ModelPackageStatus persistedModelStatus) {
-		final ModelPackageStatus desiredModelStatus = ModelPackageStatus.valueOf(status.name());
-		switch (persistedModelStatus) {
-			case DRAFT:
-				if (desiredModelStatus.equals(ModelPackageStatus.RELEASED) && !hasReferenceToDraftPackage(modelUrn, rdfModel)) {
-					throw new InvalidStateTransitionException("It is not allowed to release an aspect that has dependencies in DRAFT state.");
-				} else if (desiredModelStatus.equals(ModelPackageStatus.STANDARDIZED)) {
-					throw new IllegalArgumentException(
-						String.format("The package %s is in status %s. Only a transition to RELEASED or DEPRECATED is possible.",
-							ModelPackageUrn.fromUrn(modelUrn).getUrn(), persistedModelStatus.name()));
-				}
-				deleteByUrn(ModelPackageUrn.fromUrn(modelUrn));
-				break;
-			case RELEASED:
-				// released models can only be updated when the new state is deprecated or standardized
-				if (desiredModelStatus.equals(ModelPackageStatus.DEPRECATED) || desiredModelStatus.equals(ModelPackageStatus.STANDARDIZED)) {
-					deleteByUrn(ModelPackageUrn.fromUrn(modelUrn));
-				} else {
-					throw new IllegalArgumentException(
-						String.format("The package %s is already in status %s and cannot be modified. Only a transition to STANDARDIZED or DEPRECATED is possible.",
-							ModelPackageUrn.fromUrn(modelUrn).getUrn(), persistedModelStatus.name()));
-				}
-				break;
-			case STANDARDIZED:
-				if (desiredModelStatus.equals(ModelPackageStatus.DEPRECATED)) {
-					deleteByUrn(ModelPackageUrn.fromUrn(modelUrn));
-				} else {
-					throw new IllegalArgumentException(
-						String.format("The package %s is already in status %s and cannot be modified. Only a transition to DEPRECATED is possible.",
-							ModelPackageUrn.fromUrn(modelUrn).getUrn(), persistedModelStatus.name()));
-				}
-				break;
-			case DEPRECATED:
-				throw new IllegalArgumentException(
-					String.format("The package %s is already in status %s and cannot be modified.",
-						ModelPackageUrn.fromUrn(modelUrn).getUrn(), persistedModelStatus.name()));
-		}
-	}
+   @Override
+   public void deleteModelsPackage( final ModelPackageUrn urn ) {
+      ModelPackage modelsPackage = findByPackageByUrn( urn )
+            .orElseThrow( () -> new ModelPackageNotFoundException( urn ) );
 
-	@Override
-	public String getModelDefinition(final AspectModelUrn urn) {
-		Model jenaModelByUrn = findJenaModelByUrn(urn);
-		if (jenaModelByUrn == null) {
-			throw new AspectModelNotFoundException(urn);
-		}
-		StringWriter out = new StringWriter();
-		jenaModelByUrn.write(out, "TURTLE");
-		return out.toString();
-	}
+      ModelPackageStatus status = modelsPackage.getStatus();
+      if ( ModelPackageStatus.RELEASED.equals( status ) || ModelPackageStatus.STANDARDIZED.equals( status ) ) {
+         throw new IllegalArgumentException(
+               String.format( "The package %s is already in status %s and cannot be deleted.",
+                     urn.getUrn(), status.name() ) );
+      }
+      deleteByUrn( urn );
+   }
 
-	@Override
-	public void deleteModelsPackage(final ModelPackageUrn urn) {
-		ModelPackage modelsPackage = findByPackageByUrn(urn)
-			.orElseThrow(() -> new ModelPackageNotFoundException(urn));
+   @Override
+   public SemanticModelList findModelListByUrns( List<AspectModelUrn> urns, int page, int pageSize ) {
+      final Query query = SparqlQueries.buildFindListByUrns( urns, page, pageSize );
+      final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         rdfConnection.queryResultSet( query, resultSet -> {
+            final List<QuerySolution> querySolutions = ResultSetFormatter.toList( resultSet );
+            aspectModels.set( TripleStorePersistence.aspectModelFrom( querySolutions ) );
+         } );
+      }
+      int totalSemanticModelCount = getSelectiveItemsCount( null, null, null, null, urns );
+      int totalPages = getTotalPages( totalSemanticModelCount, pageSize );
+      SemanticModelList modelList = new SemanticModelList();
+      List<SemanticModel> semanticModels = aspectModels.get();
+      modelList.setCurrentPage( page );
+      modelList.setItemCount( semanticModels.size() );
+      modelList.setTotalPages( totalPages );
+      modelList.setTotalItems( totalSemanticModelCount );
+      modelList.setItems( aspectModels.get() );
+      return modelList;
+   }
 
-		ModelPackageStatus status = modelsPackage.getStatus();
-		if (ModelPackageStatus.RELEASED.equals(status) || ModelPackageStatus.STANDARDIZED.equals(status)) {
-			throw new IllegalArgumentException(
-				String.format("The package %s is already in status %s and cannot be deleted.",
-					urn.getUrn(), status.name()));
-		}
-		deleteByUrn(urn);
-	}
+   public boolean echo() {
+      final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build();
 
-	@Override
-	public SemanticModelList findModelListByUrns(List<AspectModelUrn> urns, int page, int pageSize) {
-		final Query query = SparqlQueries.buildFindListByUrns(urns, page, pageSize);
-		final AtomicReference<List<SemanticModel>> aspectModels = new AtomicReference<>();
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			rdfConnection.queryResultSet(query, resultSet -> {
-				final List<QuerySolution> querySolutions = ResultSetFormatter.toList(resultSet);
-				aspectModels.set(TripleStorePersistence.aspectModelFrom(querySolutions));
-			});
-		}
-		int totalSemanticModelCount = getSelectiveItemsCount(null, null, null, null, urns);
-		int totalPages = getTotalPages(totalSemanticModelCount, pageSize);
-		SemanticModelList modelList = new SemanticModelList();
-		List<SemanticModel> semanticModels = aspectModels.get();
-		modelList.setCurrentPage(page);
-		modelList.setItemCount(semanticModels.size());
-		modelList.setTotalPages(totalPages);
-		modelList.setTotalItems(totalSemanticModelCount);
-		modelList.setItems(aspectModels.get());
-		return modelList;
-	}
+      return rdfConnection.queryAsk( SparqlQueries.echoQuery() );
+   }
 
-	public boolean echo() {
-		final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build();
+   private boolean hasReferenceToDraftPackage( AspectModelUrn modelUrn, Model model ) {
+      Pattern pattern = Pattern.compile( SparqlQueries.ALL_SAMM_ASPECT_URN_PREFIX );
 
-		return rdfConnection.queryAsk(SparqlQueries.echoQuery());
-	}
+      List<String> urns = AspectModelResolver.getAllUrnsInModel( model ).stream().filter( urn -> getAspectModelUrn( urn ).isSuccess() )
+            .map( urn -> getAspectModelUrn( urn ).get().getUrnPrefix() )
+            .distinct()
+            .collect( Collectors.toList() );
 
-	private boolean hasReferenceToDraftPackage(AspectModelUrn modelUrn, Model model) {
-		Pattern pattern = Pattern.compile(SparqlQueries.ALL_SAMM_ASPECT_URN_PREFIX);
+      for ( var entry : urns ) {
+         Matcher matcher = pattern.matcher( entry );
+         if ( !matcher.find() && !modelUrn.getUrnPrefix().equals( entry ) ) {
+            if ( findByPackageByUrn( ModelPackageUrn.fromUrn( entry ) ).get().getStatus().equals( ModelPackageStatus.DRAFT ) ) {
+               return false;
+            }
+         }
+      }
 
-		List<String> urns = AspectModelResolver.getAllUrnsInModel(model).stream().filter(urn -> getAspectModelUrn(urn).isSuccess())
-			.map(urn -> getAspectModelUrn(urn).get().getUrnPrefix())
-			.distinct()
-			.collect(Collectors.toList());
+      return true;
+   }
 
-		for (var entry : urns) {
-			Matcher matcher = pattern.matcher(entry);
-			if (!matcher.find() && !modelUrn.getUrnPrefix().equals(entry)) {
-				if (findByPackageByUrn(ModelPackageUrn.fromUrn(entry)).get().getStatus().equals(ModelPackageStatus.DRAFT)) {
-					return false;
-				}
-			}
-		}
+   private Integer getTotalItemsCount( @Nullable String namespaceFilter,
+         @Nullable ModelPackageStatus status ) {
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         AtomicReference<Integer> count = new AtomicReference<>();
+         rdfConnection.querySelect(
+               SparqlQueries.buildCountAspectModelsQuery( namespaceFilter, status ),
+               querySolution -> {
+                  int countResult = querySolution.getLiteral( "aspectModelCount" ).getInt();
+                  count.set( countResult );
+               } );
+         return count.get();
+      }
+   }
 
-		return true;
-	}
+   private Integer getSelectiveItemsCount( @Nullable String namespaceFilter, @Nullable String nameFilter,
+         @Nullable String nameType,
+         @Nullable ModelPackageStatus status, List<AspectModelUrn> urns ) {
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         AtomicReference<Integer> count = new AtomicReference<>();
+         rdfConnection.querySelect(
+               SparqlQueries.buildCountSelectiveAspectModelsQuery( namespaceFilter, nameFilter, nameType, status, urns ),
+               querySolution -> {
+                  int countResult = querySolution.getLiteral( "aspectModelCount" ).getInt();
+                  count.set( countResult );
+               } );
+         return count.get();
+      }
+   }
 
-	private Integer getTotalItemsCount(@Nullable String namespaceFilter,
-									   @Nullable ModelPackageStatus status) {
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			AtomicReference<Integer> count = new AtomicReference<>();
-			rdfConnection.querySelect(
-				SparqlQueries.buildCountAspectModelsQuery(namespaceFilter, status),
-				querySolution -> {
-					int countResult = querySolution.getLiteral("aspectModelCount").getInt();
-					count.set(countResult);
-				});
-			return count.get();
-		}
-	}
+   private void deleteByUrn( final ModelPackageUrn modelsPackage ) {
+      final UpdateRequest deleteByUrn = SparqlQueries.buildDeleteByUrnRequest( modelsPackage );
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         rdfConnection.update( deleteByUrn );
+      }
+   }
 
-	private Integer getSelectiveItemsCount(@Nullable String namespaceFilter, @Nullable String nameFilter,
-										   @Nullable String nameType,
-										   @Nullable ModelPackageStatus status, List<AspectModelUrn> urns) {
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			AtomicReference<Integer> count = new AtomicReference<>();
-			rdfConnection.querySelect(
-				SparqlQueries.buildCountSelectiveAspectModelsQuery(namespaceFilter, nameFilter, nameType, status, urns),
-				querySolution -> {
-					int countResult = querySolution.getLiteral("aspectModelCount").getInt();
-					count.set(countResult);
-				});
-			return count.get();
-		}
-	}
+   private Model findContainingModelByUrn( final String urn ) {
+      final Query query = SparqlQueries.buildFindModelElementClosureQuery( urn );
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         return rdfConnection.queryConstruct( query );
+      }
+   }
 
-	private void deleteByUrn(final ModelPackageUrn modelsPackage) {
-		final UpdateRequest deleteByUrn = SparqlQueries.buildDeleteByUrnRequest(modelsPackage);
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			rdfConnection.update(deleteByUrn);
-		}
-	}
+   private Optional<ModelPackage> findByPackageByUrn( ModelPackageUrn modelsPackage ) {
+      final Query query = SparqlQueries.buildFindByPackageQuery( modelsPackage );
+      final AtomicReference<String> aspectModel = new AtomicReference<>();
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         rdfConnection.querySelect( query,
+               result -> aspectModel.set( result.get( SparqlQueries.STATUS_RESULT ).toString() ) );
+      }
+      if ( aspectModel.get() != null ) {
+         return Optional.of( new ModelPackage( ModelPackageStatus.valueOf( aspectModel.get() ) ) );
+      }
+      return Optional.empty();
+   }
 
-	private Model findContainingModelByUrn(final String urn) {
-		final Query query = SparqlQueries.buildFindModelElementClosureQuery(urn);
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			return rdfConnection.queryConstruct(query);
-		}
-	}
+   private SemanticModel findByUrn( final AspectModelUrn urn ) {
+      final Query query = SparqlQueries.buildFindByUrnQuery( urn );
+      final AtomicReference<SemanticModel> aspectModel = new AtomicReference<>();
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         rdfConnection.querySelect( query,
+               result -> aspectModel.set( TripleStorePersistence.aspectModelFrom( result ) ) );
+      }
+      return aspectModel.get();
+   }
 
-	private Optional<ModelPackage> findByPackageByUrn(ModelPackageUrn modelsPackage) {
-		final Query query = SparqlQueries.buildFindByPackageQuery(modelsPackage);
-		final AtomicReference<String> aspectModel = new AtomicReference<>();
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			rdfConnection.querySelect(query,
-				result -> aspectModel.set(result.get(SparqlQueries.STATUS_RESULT).toString()));
-		}
-		if (aspectModel.get() != null) {
-			return Optional.of(new ModelPackage(ModelPackageStatus.valueOf(aspectModel.get())));
-		}
-		return Optional.empty();
-	}
+   private Model findJenaModelByUrn( final AspectModelUrn urn ) {
+      final Query constructQuery = SparqlQueries.buildFindByUrnConstructQuery( urn );
+      try ( final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build() ) {
+         return rdfConnection.queryConstruct( constructQuery );
+      }
+   }
 
-	private SemanticModel findByUrn(final AspectModelUrn urn) {
-		final Query query = SparqlQueries.buildFindByUrnQuery(urn);
-		final AtomicReference<SemanticModel> aspectModel = new AtomicReference<>();
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			rdfConnection.querySelect(query,
-				result -> aspectModel.set(TripleStorePersistence.aspectModelFrom(result)));
-		}
-		return aspectModel.get();
-	}
+   private Try<AspectModelUrn> getAspectModelUrn( String urn ) {
+      try {
+         return Try.success( AspectModelUrn.fromUrn( urn ) );
+      } catch ( UrnSyntaxException var2 ) {
+         return Try.failure( var2 );
+      }
+   }
 
-	private Model findJenaModelByUrn(final AspectModelUrn urn) {
-		final Query constructQuery = SparqlQueries.buildFindByUrnConstructQuery(urn);
-		try (final RDFConnection rdfConnection = rdfConnectionRemoteBuilder.build()) {
-			return rdfConnection.queryConstruct(constructQuery);
-		}
-	}
+   private static List<SemanticModel> aspectModelFrom(
+         final List<QuerySolution> querySolutions ) {
+      return querySolutions
+            .stream()
+            .map( TripleStorePersistence::aspectModelFrom )
+            .collect( Collectors.toList() );
+   }
 
-	private Try<AspectModelUrn> getAspectModelUrn(String urn) {
-		try {
-			return Try.success(AspectModelUrn.fromUrn(urn));
-		} catch (UrnSyntaxException var2) {
-			return Try.failure(var2);
-		}
-	}
+   private static SemanticModel aspectModelFrom( final QuerySolution querySolution ) {
+      final String urn = querySolution.get( SparqlQueries.ASPECT ).toString();
+      final String status = querySolution.get( SparqlQueries.STATUS_RESULT ).toString();
+      AspectModelUrn aspectModelUrn = AspectModelUrn.fromUrn( urn );
+      SemanticModel model = new SemanticModel();
+      model.setUrn( aspectModelUrn.getUrn().toString() );
+      model.setType( determineModelType(urn) );
+      model.setVersion( aspectModelUrn.getVersion() );
+      model.setName( aspectModelUrn.getName() );
+      model.setStatus( SemanticModelStatus.fromValue( status ) );
+      return model;
+   }
 
+   private static SemanticModelType determineModelType(String aspectUrn){
+      if(aspectUrn.contains( "bamm" )){
+         return SemanticModelType.BAMM;
+      }else{
+         return SemanticModelType.SAMM;
+      }
+   }
 	private void validateStatusParameter(SemanticModelStatus status) {
 		if (ObjectUtils.allNull(status)) {
 			throw new IllegalArgumentException(

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.jena.arq.querybuilder.UpdateBuilder;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QuerySolution;
@@ -107,6 +108,7 @@ public class TripleStorePersistence implements PersistenceLayer {
    @Override
    public SemanticModel updateModel( String urn, SemanticModelStatus status ) {
 
+	  validateStatusParameter(status);
       SemanticModel semanticModel = Optional.ofNullable( findByUrn(
             AspectModelUrn.fromUrn( urn ) ) ).orElseThrow( () -> new IllegalArgumentException(
             String.format( "Invalid URN %s",
@@ -127,6 +129,7 @@ public class TripleStorePersistence implements PersistenceLayer {
 
    @Override
    public SemanticModel save( SemanticModelType type, String newModel, SemanticModelStatus status ) {
+	  validateStatusParameter(status);
       final Model rdfModel = sdsSdk.load( newModel.getBytes( StandardCharsets.UTF_8 ) );
       final AspectModelUrn modelUrn = sdsSdk.getAspectUrn( rdfModel );
       Optional<ModelPackage> existsByPackage = findByPackageByUrn( ModelPackageUrn.fromUrn( modelUrn ) );
@@ -376,4 +379,10 @@ public class TripleStorePersistence implements PersistenceLayer {
          return SemanticModelType.SAMM;
       }
    }
+	private void validateStatusParameter(SemanticModelStatus status) {
+		if (ObjectUtils.allNull(status)) {
+			throw new IllegalArgumentException(
+				"SemanticModelStatus cannot be null. Valid values are: DRAFT, RELEASED, STANDARDIZED, DEPRECATED.");
+		}
+	}
 }

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/hub/persistence/triplestore/TripleStorePersistence.java
@@ -378,10 +378,9 @@ public class TripleStorePersistence implements PersistenceLayer {
          return SemanticModelType.SAMM;
       }
    }
-	private void validateStatusParameter(SemanticModelStatus status) {
-		if (ObjectUtils.allNull(status)) {
-			throw new IllegalArgumentException(
-				"SemanticModelStatus cannot be null. Valid values are: DRAFT, RELEASED, STANDARDIZED, DEPRECATED.");
-		}
-	}
+   private void validateStatusParameter(SemanticModelStatus status) {
+      if (ObjectUtils.allNull(status)) {
+	throw new IllegalArgumentException("SemanticModelStatus cannot be null. Valid values are: DRAFT, RELEASED, STANDARDIZED, DEPRECATED.");
+      }
+   }
 }

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
@@ -1069,7 +1069,6 @@ public class ModelsApiTest extends AbstractModelsApiTest{
             .andExpect( status().isBadRequest() )
             .andExpect( jsonPath( "$.error.message", containsString( "Invalid URN urn" ) ) );
    }
-
 	@Test
 	public void testUpdateModelWithNullStatusExpectBadRequest() throws Exception {
 		String urnPrefix = "urn:samm:org.eclipse.tractusx.valid.save:2.0.0#";

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
@@ -1070,4 +1070,25 @@ public class ModelsApiTest extends AbstractModelsApiTest{
             .andExpect( jsonPath( "$.error.message", containsString( "Invalid URN urn" ) ) );
    }
 
+	@Test
+	public void testUpdateModelWithNullStatusExpectBadRequest() throws Exception {
+		String urnPrefix = "urn:samm:org.eclipse.tractusx.valid.save:2.0.0#";
+		mvc.perform(
+				put( TestUtils.createValidModelRequest(urnPrefix),null)
+			)
+			.andDo( MockMvcResultHandlers.print() )
+			.andExpect( status().isBadRequest() )
+			.andExpect( jsonPath( "$.error.message", containsString( "SemanticModelStatus cannot be null" ) ) );
+	}
+
+	@Test
+	public void testSaveModelWithNullStatusExpectBadRequest() throws Exception {
+		String urnPrefix = "urn:samm:org.eclipse.tractusx.valid.save:2.0.0#";
+		mvc.perform(
+				post( TestUtils.createValidModelRequest(urnPrefix),null)
+			)
+			.andDo( MockMvcResultHandlers.print() )
+			.andExpect( status().isBadRequest() )
+			.andExpect( jsonPath( "$.error.message", containsString( "SemanticModelStatus cannot be null" ) ) );
+	}
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
This PR for save and update api to properly handle cases where the SemanticModelStatus parameter is null. Instead of resulting in an internal server error (HTTP 500), the application now returns a 400 Bad Request with a descriptive error message. 

## Fix 
- Error Handling: Updated the logic to check for null values in the SemanticModelStatus parameter for both save and 
updateModel methods.
- Response Update: Modified the API response to return a 400 Bad Request status when SemanticModelStatus is null, instead of a 500 Internal Server Error.
- Error Message: Provided a clear and informative error message: "SemanticModelStatus cannot be null. Valid values are: DRAFT, RELEASED, STANDARDIZED, DEPRECATED."

## Issue:
Fixes #289


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
