### PR TITLE
feature: sonar cloud & jacoco code coverage integration with GitHub pipeline

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload JaCoCo Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jacoco-report
           path: target/site/jacoco
@@ -71,7 +71,6 @@ jobs:
             restore-keys: ${{ runner.os }}-sonar
 
       - name: Analyze with Sonar
-        if: ${{ secrets.SONAR_TOKEN != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -19,7 +19,7 @@
 
 name: "Build"
 
-on:   
+on:
   push:
     branches:
       - main
@@ -35,7 +35,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions: 
+    permissions:
       contents: read
       packages: write
     steps:
@@ -57,3 +57,23 @@ jobs:
         run: mvn clean install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload JaCoCo Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-report
+          path: target/site/jacoco
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+            path: ~/.sonar/cache
+            key: ${{ runner.os }}-sonar
+            restore-keys: ${{ runner.os }}-sonar
+
+      - name: Analyze with Sonar
+        if: ${{ secrets.SONAR_TOKEN != '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn --batch-mode verify sonar:sonar -Dsonar.projectKey=smartsensesolutions_sldt-semantic-hub -Dsonar.organization=smartsensesolutions
+

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -19,7 +19,7 @@
 
 name: "Build"
 
-on:   
+on:
   push:
     branches:
       - main
@@ -35,7 +35,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions: 
+    permissions:
       contents: read
       packages: write
     steps:
@@ -57,3 +57,22 @@ jobs:
         run: mvn clean install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload JaCoCo Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+            path: ~/.sonar/cache
+            key: ${{ runner.os }}-sonar
+            restore-keys: ${{ runner.os }}-sonar
+
+      - name: Analyze with Sonar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn --batch-mode verify sonar:sonar -Dsonar.projectKey=eclipse-tractusx_sldt-semantic-hub -Dsonar.organization=eclipse-tractusx
+

--- a/.tractusx
+++ b/.tractusx
@@ -19,6 +19,7 @@
 ###############################################################
 
 product: "Semantic Hub"
+category: 'product'
 leadingRepository: "https://github.com/eclipse-tractusx/sldt-semantic-hub"
 openApiSpecs: https://github.com/eclipse-tractusx/sldt-semantic-hub/blob/main/backend/src/main/resources/static/semantic-hub-openapi.yaml
 repositories:

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<!-- semantics -->
-        <samm.sdk.version>2.9.8</samm.sdk.version>
+		<samm.sdk.version>2.9.8</samm.sdk.version>
 		<jena.version>5.0.0</jena.version>
 		<shacl.version>1.3.1</shacl.version>
 		<apache.http.client.version>4.5.12</apache.http.client.version>
@@ -112,10 +112,19 @@
 		<junit.version>4.13.2</junit.version>
 		<testcontainer.version>1.17.6</testcontainer.version>
 		<spring-security.version>6.3.4</spring-security.version>
+		<jacoco.version>0.8.12</jacoco.version>
 		<!-- build -->
 		<maven.compiler.version>3.8.1</maven.compiler.version>
 		<license-tool-plugin-version>1.1.0</license-tool-plugin-version>
+		<sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
 
+		<!-- Sonar Cloud properties -->
+		<sonar.organization>eclipse-tractusx</sonar.organization>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+		<sonar.projectKey>eclipse-tractusx_sldt-semantic-hub</sonar.projectKey>
+		<sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
+		<sonar.projectName>sldt-semantic-hub</sonar.projectName>
+		<sonar.java.source>17</sonar.java.source>
 	</properties>
 
 	<modules>
@@ -327,11 +336,6 @@
 				<groupId>org.eclipse.esmf</groupId>
 				<artifactId>esmf-aspect-model-starter</artifactId>
 				<version>${samm.sdk.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-text</artifactId>
-				<version>1.10.0</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>
@@ -557,6 +561,34 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<formats>
+								<format>XML</format>
+								<format>HTML</format> <!-- Add HTML to check report in a browser -->
+							</formats>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<!-- semantics -->
-        <samm.sdk.version>2.9.8</samm.sdk.version>
+		<samm.sdk.version>2.9.8</samm.sdk.version>
 		<jena.version>5.0.0</jena.version>
 		<shacl.version>1.3.1</shacl.version>
 		<apache.http.client.version>4.5.12</apache.http.client.version>
@@ -112,10 +112,19 @@
 		<junit.version>4.13.2</junit.version>
 		<testcontainer.version>1.17.6</testcontainer.version>
 		<spring-security.version>6.3.4</spring-security.version>
+		<jacoco.version>0.8.12</jacoco.version>
 		<!-- build -->
 		<maven.compiler.version>3.8.1</maven.compiler.version>
 		<license-tool-plugin-version>1.1.0</license-tool-plugin-version>
+		<sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
 
+		<!-- Sonar Cloud properties -->
+		<sonar.organization>eclipse-tractusx</sonar.organization>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+		<sonar.projectKey>eclipse-tractusx_sldt-semantic-hub</sonar.projectKey>
+		<sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
+		<sonar.projectName>sldt-semantic-hub</sonar.projectName>
+		<sonar.java.source>17</sonar.java.source>
 	</properties>
 
 	<modules>
@@ -557,6 +566,34 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<formats>
+								<format>XML</format>
+								<format>HTML</format> <!-- Add HTML to check report in a browser -->
+							</formats>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -338,11 +338,6 @@
 				<version>${samm.sdk.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-text</artifactId>
-				<version>1.10.0</version>
-			</dependency>
-			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
 				<version>${commons-io.version}</version>


### PR DESCRIPTION
## Description

- Integrated SonarCloud and JaCoCo for code quality and coverage analysis.
- Added GitHub Actions pipeline to automatically upload Sonar and JaCoCo reports during the build process.

## issue

https://github.com/eclipse-tractusx/sldt-semantic-hub/issues/315

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
