### PR TITLE
chore: upgrade ESMF SDK to 2.10.3 with SAMM 2.2.0 support

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -30,7 +30,7 @@ on:
       - synchronize
 
 env:
-  FUSEKI_VERSION: 5.0.0
+  FUSEKI_VERSION: 5.3.0
 
 jobs:
   build:
@@ -40,11 +40,11 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
       - name: Pull Fuseki sources
         run: curl https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/$FUSEKI_VERSION/jena-fuseki-docker-$FUSEKI_VERSION.zip > ./jena-fuseki.zip

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
           cache: maven
       - name: Pull Fuseki sources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           java-version: '21'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/publish-image-semantic-hub.yml
+++ b/.github/workflows/publish-image-semantic-hub.yml
@@ -48,11 +48,11 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Setup Maven Action
         uses: s4u/setup-maven-action@v1.7.0
         with:
-          java-version: 17
+          java-version: 21
       - name: execute-maven-deps
         working-directory: ./backend
         run: mvn verify dependency:list -DskipTests -Dmaven.javadoc.skip=true -DappendOutput=false -DoutputFile=maven.deps -DincludeScope=compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
           cache: maven
       - name: setup git config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
         required: true
 
 env:
-  FUSEKI_VERSION: 5.0.0
+  FUSEKI_VERSION: 5.3.0
 
 jobs:
   build:
@@ -38,11 +38,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: release
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: maven
       - name: setup git config
         run: |

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
       - name: Build JAR
         run: mvn clean package -DskipTests
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Upgrade ESMF SDK to version 2.10.3 with support for SAMM 2.2.0
+- Upgrade Jena client libraries to version 5.3.0 (required by ESMF SDK 2.10.x)
+- Upgrade to Java 21 (required by ESMF SDK 2.10.x) in build, CI workflows and Docker images
+- Update lombok to version 1.18.38
+- Update testcontainers to version 1.21.4 for compatibility with current Docker Engine releases
+
 ## 0.6.0
 ### fixed
 - fixed cve CVE-2024-38819 spring-webmvc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Added docker-compose setup for local deployment (`docker-compose.yml`, see `docs/local-deployment-docker-compose.md`)
+
 ### Changed
 - Upgrade ESMF SDK to version 2.10.3 with support for SAMM 2.2.0
 - Upgrade Jena client libraries to version 5.3.0 (required by ESMF SDK 2.10.x)
-- Upgrade to Java 21 (required by ESMF SDK 2.10.x) in build, CI workflows and Docker images
+- **Breaking (build/runtime requirement):** Upgrade to Java 21 (required by ESMF SDK 2.10.x) in build, CI workflows and Docker images
+- Align Fuseki triple store image with the Jena client libraries: jena-fuseki-docker 5.0.0 -> 5.3.0 (CI, Helm values, docker-compose, documentation)
 - Update lombok to version 1.18.38
 - Update testcontainers to version 1.21.4 for compatibility with current Docker Engine releases
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,9 +1,9 @@
 maven/mavencentral/ch.qos.logback/logback-classic/1.4.14, EPL-1.0 AND LGPL-2.1-only, approved, #15230
 maven/mavencentral/ch.qos.logback/logback-core/1.4.14, EPL-1.0 AND LGPL-2.1-only, approved, #15209
-maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.0, Apache-2.0, approved, #15200
-maven/mavencentral/com.ethlo.time/itu/1.8.0, Apache-2.0, approved, #12927
+maven/mavencentral/com.apicatalog/titanium-json-ld/1.4.1, Apache-2.0, approved, #15200
+maven/mavencentral/com.ethlo.time/itu/1.10.2, Apache-2.0, approved, #13168
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.15.4, Apache-2.0, approved, #15260
-maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.4, , approved, #15194
+maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.15.4, Apache-2.0 AND MIT AND BSD-2-Clause, approved, #15194
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.0, Apache-2.0, approved, #4105
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.12.7, Apache-2.0, approved, #5575
 maven/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.15.4, Apache-2.0, approved, #15207
@@ -14,23 +14,30 @@ maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2
 maven/mavencentral/com.fasterxml.woodstox/woodstox-core/6.4.0, Apache-2.0, approved, #5309
 maven/mavencentral/com.fasterxml/classmate/1.6.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/com.github.andrewoma.dexx/collection/0.7, MIT, approved, CQ22160
-maven/mavencentral/com.github.ben-manes.caffeine/caffeine/3.1.8, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.github.ben-manes.caffeine/caffeine/3.1.8, Apache-2.0 AND (Apache-2.0 AND CC0-1.0), approved, #19704
 maven/mavencentral/com.github.curious-odd-man/rgxgen/2.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.github.docker-java/docker-java-api/3.4.2, Apache-2.0, approved, #20872
+maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.4.2, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15745
+maven/mavencentral/com.github.docker-java/docker-java-transport/3.4.2, Apache-2.0, approved, #20873
+maven/mavencentral/com.github.luben/zstd-jni/1.5.7-9, BSD-2-Clause, approved, #19830
 maven/mavencentral/com.github.stephenc.jcip/jcip-annotations/1.0-1, Apache-2.0, approved, CQ21949
-maven/mavencentral/com.github.virtuald/curvesapi/1.08, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.github.virtuald/curvesapi/1.08, BSD-3-Clause AND Apache-2.0, approved, #23170
 maven/mavencentral/com.google.code.findbugs/jsr305/3.0.2, Apache-2.0 and CC-BY-2.5, approved, #15220
 maven/mavencentral/com.google.code.gson/gson/2.10.1, Apache-2.0, approved, #6159
-maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.google.errorprone/error_prone_annotations/2.18.0, Apache-2.0, approved, #26405
 maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, CQ22654
 maven/mavencentral/com.google.guava/guava/32.1.1-jre, Apache-2.0 AND CC0-1.0 AND LicenseRef-Public-Domain, approved, #9229
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
-maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.ibm.icu/icu4j/72.1, ICU, approved, #4354
-maven/mavencentral/com.networknt/json-schema-validator/1.4.0, Apache-2.0 AND Unicode-TOU, approved, #13812
+maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, #23147
+maven/mavencentral/com.jayway.jsonpath/json-path/2.9.0, Apache-2.0, approved, #20009
+maven/mavencentral/com.networknt/json-schema-validator/1.5.4, Apache-2.0 AND Unicode-TOU, approved, #15630
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
+maven/mavencentral/com.vaadin.external.google/android-json/0.0.20131108.vaadin1, Apache-2.0, approved, CQ21310
 maven/mavencentral/com.zaxxer/SparseBitSet/1.3, Apache-2.0, approved, #10726
-maven/mavencentral/commons-cli/commons-cli/1.6.0, Apache-2.0, approved, #11339
+maven/mavencentral/commons-beanutils/commons-beanutils/1.9.4, Apache-2.0, approved, CQ12654
+maven/mavencentral/commons-cli/commons-cli/1.9.0, Apache-2.0, approved, #15950
 maven/mavencentral/commons-codec/commons-codec/1.16.1, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #9157
+maven/mavencentral/commons-collections/commons-collections/3.2.2, Apache-2.0, approved, #15185
 maven/mavencentral/commons-fileupload/commons-fileupload/1.5, Apache-2.0, approved, #7109
 maven/mavencentral/commons-io/commons-io/2.17.0, Apache-2.0, approved, #16198
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
@@ -40,11 +47,11 @@ maven/mavencentral/io.micrometer/micrometer-core/1.12.5, Apache-2.0 AND (Apache-
 maven/mavencentral/io.micrometer/micrometer-jakarta9/1.12.5, Apache-2.0, approved, #12923
 maven/mavencentral/io.micrometer/micrometer-observation/1.12.5, Apache-2.0, approved, #11680
 maven/mavencentral/io.micrometer/micrometer-registry-prometheus/1.12.5, Apache-2.0, approved, #14187
-maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.prometheus/simpleclient_common/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.prometheus/simpleclient/0.16.0, Apache-2.0 AND CC0-1.0, approved, #19721
+maven/mavencentral/io.prometheus/simpleclient_common/0.16.0, Apache-2.0, approved, #19730
+maven/mavencentral/io.prometheus/simpleclient_tracer_common/0.16.0, Apache-2.0, approved, #19716
+maven/mavencentral/io.prometheus/simpleclient_tracer_otel/0.16.0, Apache-2.0, approved, #20002
+maven/mavencentral/io.prometheus/simpleclient_tracer_otel_agent/0.16.0, Apache-2.0, approved, #19706
 maven/mavencentral/io.swagger.core.v3/swagger-annotations-jakarta/2.2.7, Apache-2.0, approved, #5947
 maven/mavencentral/io.swagger.core.v3/swagger-annotations/2.0.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/io.swagger.core.v3/swagger-core-jakarta/2.2.7, Apache-2.0, approved, #5929
@@ -65,90 +72,116 @@ maven/mavencentral/jakarta.websocket/jakarta.websocket-api/2.1.1, EPL-2.0 OR GPL
 maven/mavencentral/jakarta.websocket/jakarta.websocket-client-api/2.1.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.websocket
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/javax.activation/javax.activation-api/1.2.0, (CDDL-1.1 OR GPL-2.0 WITH Classpath-exception-2.0) AND Apache-2.0, approved, CQ18740
+maven/mavencentral/javax.inject/javax.inject/1, Apache-2.0, approved, CQ3555
 maven/mavencentral/javax.xml.bind/jaxb-api/2.3.1, CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0, approved, CQ16911
+maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
+maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.13, Apache-2.0, approved, #7164
+maven/mavencentral/net.bytebuddy/byte-buddy/1.14.13, Apache-2.0 AND BSD-3-Clause, approved, #7163
+maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
+maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, #19432
+maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, #19431
 maven/mavencentral/org.antlr/antlr4-runtime/4.5.3, BSD-2-Clause, approved, CQ9834
 maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, #17660
 maven/mavencentral/org.apache.commons/commons-compress/1.26.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #13288
-maven/mavencentral/org.apache.commons/commons-csv/1.10.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-csv/1.13.0, Apache-2.0, approved, #18551
 maven/mavencentral/org.apache.commons/commons-fileupload2-core/2.0.0-M2, Apache-2.0, approved, #15738
-maven/mavencentral/org.apache.commons/commons-fileupload2-jakarta-servlet6/2.0.0-M2, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-fileupload2-jakarta-servlet6/2.0.0-M2, Apache-2.0, approved, #21710
 maven/mavencentral/org.apache.commons/commons-lang3/3.13.0, Apache-2.0, approved, #9820
 maven/mavencentral/org.apache.commons/commons-math3/3.6.1, Apache-2.0 AND BSD-3-Clause AND BSD-2-Clause, approved, CQ22025
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.12, Apache-2.0, approved, #15248
 maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.16, Apache-2.0, approved, CQ23528
-maven/mavencentral/org.apache.jena/apache-jena-libs/5.0.0, Apache-2.0, approved, #19059
-maven/mavencentral/org.apache.jena/jena-arq/5.0.0, Apache-2.0 AND (Apache-2.0 AND EPL-2.0) AND (Apache-2.0 AND EPL-1.0), approved, #15690
-maven/mavencentral/org.apache.jena/jena-base/5.0.0, Apache-2.0, approved, #15685
-maven/mavencentral/org.apache.jena/jena-cmds/5.0.0, Apache-2.0, approved, #19048
-maven/mavencentral/org.apache.jena/jena-core/5.0.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15686
-maven/mavencentral/org.apache.jena/jena-dboe-base/5.0.0, Apache-2.0, approved, #19052
-maven/mavencentral/org.apache.jena/jena-dboe-index/5.0.0, Apache-2.0, approved, #19049
-maven/mavencentral/org.apache.jena/jena-dboe-storage/5.0.0, Apache-2.0, approved, #19051
-maven/mavencentral/org.apache.jena/jena-dboe-trans-data/5.0.0, Apache-2.0, approved, #19063
-maven/mavencentral/org.apache.jena/jena-dboe-transaction/5.0.0, Apache-2.0, approved, #19056
-maven/mavencentral/org.apache.jena/jena-fuseki-access/5.0.0, Apache-2.0, approved, #19050
-maven/mavencentral/org.apache.jena/jena-fuseki-core/5.0.0, Apache-2.0 AND (EPL-2.0 OR Apache-2.0), approved, #19055
-maven/mavencentral/org.apache.jena/jena-fuseki-main/5.0.0, Apache-2.0, approved, #19053
-maven/mavencentral/org.apache.jena/jena-iri/5.0.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.apache.jena/jena-querybuilder/5.0.0, Apache-2.0, approved, #19060
-maven/mavencentral/org.apache.jena/jena-rdfconnection/5.0.0, Apache-2.0, approved, #19057
-maven/mavencentral/org.apache.jena/jena-rdfpatch/5.0.0, Apache-2.0, approved, #19054
-maven/mavencentral/org.apache.jena/jena-shacl/5.0.0, Apache-2.0 AND W3C-20150513, approved, #15688
-maven/mavencentral/org.apache.jena/jena-shex/5.0.0, Apache-2.0, approved, #19062
-maven/mavencentral/org.apache.jena/jena-tdb1/5.0.0, Apache-2.0, approved, #19061
-maven/mavencentral/org.apache.jena/jena-tdb2/5.0.0, Apache-2.0, approved, #19058
+maven/mavencentral/org.apache.jena/jena-arq/5.3.0, Apache-2.0 AND (Apache-2.0 AND EPL-2.0) AND (EPL-2.0 OR Apache-2.0), approved, #20098
+maven/mavencentral/org.apache.jena/jena-base/5.3.0, Apache-2.0 AND MIT, approved, clearlydefined
+maven/mavencentral/org.apache.jena/jena-cmds/5.3.0, Apache-2.0, approved, #25073
+maven/mavencentral/org.apache.jena/jena-core/5.3.0, Apache-2.0 AND MIT, approved, clearlydefined
+maven/mavencentral/org.apache.jena/jena-dboe-base/5.3.0, Apache-2.0, approved, #25084
+maven/mavencentral/org.apache.jena/jena-dboe-index/5.3.0, Apache-2.0, approved, #25066
+maven/mavencentral/org.apache.jena/jena-dboe-storage/5.3.0, Apache-2.0, approved, #25091
+maven/mavencentral/org.apache.jena/jena-dboe-trans-data/5.3.0, Apache-2.0, approved, #25096
+maven/mavencentral/org.apache.jena/jena-dboe-transaction/5.3.0, Apache-2.0, approved, #25088
+maven/mavencentral/org.apache.jena/jena-fuseki-access/5.3.0, Apache-2.0, approved, #25090
+maven/mavencentral/org.apache.jena/jena-fuseki-core/5.3.0, Apache-2.0 AND (EPL-2.0 OR Apache-2.0), approved, #25104
+maven/mavencentral/org.apache.jena/jena-fuseki-main/5.3.0, Apache-2.0, approved, #25064
+maven/mavencentral/org.apache.jena/jena-iri/5.3.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.jena/jena-iri3986/5.3.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.jena/jena-querybuilder/5.3.0, , restricted, clearlydefined
+maven/mavencentral/org.apache.jena/jena-rdfconnection/5.3.0, Apache-2.0, approved, #25077
+maven/mavencentral/org.apache.jena/jena-rdfpatch/5.3.0, Apache-2.0, approved, #25109
+maven/mavencentral/org.apache.jena/jena-shacl/5.3.0, Apache-2.0 AND W3C-20150513, approved, #25070
+maven/mavencentral/org.apache.jena/jena-shex/5.3.0, Apache-2.0, approved, #25071
+maven/mavencentral/org.apache.jena/jena-tdb1/5.3.0, Apache-2.0, approved, #25103
+maven/mavencentral/org.apache.jena/jena-tdb2/5.3.0, Apache-2.0, approved, #25097
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.21.1, Apache-2.0 AND (Apache-2.0 AND LGPL-2.0-or-later), approved, #11079
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.21.1, Apache-2.0, approved, #15262
-maven/mavencentral/org.apache.poi/poi-ooxml-lite/5.2.5, Apache-2.0 AND BSD-3-Clause AND MIT AND Apache-2.0 AND W3C-19980720, approved, #5247
-maven/mavencentral/org.apache.poi/poi-ooxml/5.2.5, Apache-2.0 AND BSD-3-Clause AND MIT AND Apache-2.0, approved, #5243
-maven/mavencentral/org.apache.poi/poi/5.3.0, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #15532
-maven/mavencentral/org.apache.thrift/libthrift/0.19.0, Apache-2.0, approved, #15687
+maven/mavencentral/org.apache.maven.shared/maven-shared-utils/3.4.2, Apache-2.0, approved, #13658
+maven/mavencentral/org.apache.poi/poi-ooxml-lite/5.4.0, Apache-2.0 AND MIT AND Apache-2.0 AND W3C-19980720, approved, #18529
+maven/mavencentral/org.apache.poi/poi-ooxml/5.4.0, Apache-2.0 AND MIT AND Apache-2.0, approved, #18527
+maven/mavencentral/org.apache.poi/poi/5.4.0, Apache-2.0 AND (Apache-2.0 AND MIT), approved, #18526
+maven/mavencentral/org.apache.shiro.crypto/shiro-hashes-argon2/2.0.2, Apache-2.0 AND LicenseRef-scancode-public-domain AND MIT, restricted, clearlydefined
+maven/mavencentral/org.apache.shiro.crypto/shiro-hashes-bcrypt/2.0.2, Apache-2.0 AND LicenseRef-scancode-public-domain AND MIT, restricted, clearlydefined
+maven/mavencentral/org.apache.shiro/shiro-cache/2.0.2, Apache-2.0, approved, #23776
+maven/mavencentral/org.apache.shiro/shiro-config-core/2.0.2, Apache-2.0, approved, #23811
+maven/mavencentral/org.apache.shiro/shiro-config-ogdl/2.0.2, Apache-2.0 AND MIT, approved, clearlydefined
+maven/mavencentral/org.apache.shiro/shiro-core/2.0.2, Apache-2.0, approved, #23778
+maven/mavencentral/org.apache.shiro/shiro-crypto-cipher/2.0.2, Apache-2.0, approved, #25105
+maven/mavencentral/org.apache.shiro/shiro-crypto-core/2.0.2, Apache-2.0, approved, #25108
+maven/mavencentral/org.apache.shiro/shiro-crypto-hash/2.0.2, Apache-2.0, approved, #23775
+maven/mavencentral/org.apache.shiro/shiro-event/2.0.2, Apache-2.0, approved, #23774
+maven/mavencentral/org.apache.shiro/shiro-lang/2.0.2, Apache-2.0 AND Beerware, approved, #23826
+maven/mavencentral/org.apache.shiro/shiro-web/2.0.2, Apache-2.0 AND BSD-3-Clause AND MIT, approved, clearlydefined
+maven/mavencentral/org.apache.thrift/libthrift/0.21.0, Apache-2.0, approved, #20095
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.20, Apache-2.0, approved, #6997
-maven/mavencentral/org.apache.velocity/velocity-engine-core/2.4, Apache-2.0, approved, #16799
-maven/mavencentral/org.apache.xmlbeans/xmlbeans/5.2.0, Apache-2.0, approved, #11782
-maven/mavencentral/org.apache.xmlgraphics/batik-anim/1.17, Apache-2.0, approved, #10144
-maven/mavencentral/org.apache.xmlgraphics/batik-awt-util/1.17, Apache-2.0, approved, #10149
-maven/mavencentral/org.apache.xmlgraphics/batik-bridge/1.17, Apache-2.0, approved, #10152
-maven/mavencentral/org.apache.xmlgraphics/batik-codec/1.17, Apache-2.0, approved, #10155
-maven/mavencentral/org.apache.xmlgraphics/batik-constants/1.17, Apache-2.0, approved, #10158
-maven/mavencentral/org.apache.xmlgraphics/batik-css/1.17, Apache-2.0, approved, #10141
-maven/mavencentral/org.apache.xmlgraphics/batik-dom/1.17, Apache-2.0 AND W3C, approved, #10140
-maven/mavencentral/org.apache.xmlgraphics/batik-ext/1.17, Apache-2.0 AND W3C, approved, #10142
-maven/mavencentral/org.apache.xmlgraphics/batik-gvt/1.17, Apache-2.0, approved, #10157
-maven/mavencentral/org.apache.xmlgraphics/batik-i18n/1.17, Apache-2.0, approved, #10154
-maven/mavencentral/org.apache.xmlgraphics/batik-parser/1.17, Apache-2.0, approved, #10139
-maven/mavencentral/org.apache.xmlgraphics/batik-rasterizer/1.17, Apache-2.0, approved, #10145
-maven/mavencentral/org.apache.xmlgraphics/batik-script/1.17, Apache-2.0, approved, #10148
-maven/mavencentral/org.apache.xmlgraphics/batik-shared-resources/1.17, Apache-2.0, approved, #10147
-maven/mavencentral/org.apache.xmlgraphics/batik-svg-dom/1.17, Apache-2.0 AND W3C, approved, #10143
-maven/mavencentral/org.apache.xmlgraphics/batik-svggen/1.17, Apache-2.0, approved, #10151
-maven/mavencentral/org.apache.xmlgraphics/batik-svgrasterizer/1.17, Apache-2.0, approved, #10146
-maven/mavencentral/org.apache.xmlgraphics/batik-transcoder/1.17, Apache-2.0, approved, #10156
-maven/mavencentral/org.apache.xmlgraphics/batik-util/1.17, Apache-2.0, approved, #10150
-maven/mavencentral/org.apache.xmlgraphics/batik-xml/1.17, Apache-2.0, approved, #10153
-maven/mavencentral/org.apache.xmlgraphics/xmlgraphics-commons/2.9, Apache-2.0, approved, #15397
+maven/mavencentral/org.apache.velocity/velocity-engine-core/2.4.1, Apache-2.0, approved, #24420
+maven/mavencentral/org.apache.xmlbeans/xmlbeans/5.3.0, Apache-2.0 AND W3C-19980720, approved, #17930
+maven/mavencentral/org.apache.xmlgraphics/batik-anim/1.18, Apache-2.0, approved, #16572
+maven/mavencentral/org.apache.xmlgraphics/batik-awt-util/1.18, Apache-2.0, approved, #16558
+maven/mavencentral/org.apache.xmlgraphics/batik-bridge/1.18, Apache-2.0, approved, #16596
+maven/mavencentral/org.apache.xmlgraphics/batik-codec/1.18, Apache-2.0, approved, #16568
+maven/mavencentral/org.apache.xmlgraphics/batik-constants/1.18, Apache-2.0, approved, #16575
+maven/mavencentral/org.apache.xmlgraphics/batik-css/1.18, Apache-2.0, approved, #16597
+maven/mavencentral/org.apache.xmlgraphics/batik-dom/1.18, Apache-2.0 AND W3C, approved, #16576
+maven/mavencentral/org.apache.xmlgraphics/batik-ext/1.18, Apache-2.0 AND W3C, approved, #16594
+maven/mavencentral/org.apache.xmlgraphics/batik-gvt/1.18, Apache-2.0, approved, #16561
+maven/mavencentral/org.apache.xmlgraphics/batik-i18n/1.18, Apache-2.0, approved, #16582
+maven/mavencentral/org.apache.xmlgraphics/batik-parser/1.18, Apache-2.0, approved, #16564
+maven/mavencentral/org.apache.xmlgraphics/batik-rasterizer/1.18, Apache-2.0, approved, #16812
+maven/mavencentral/org.apache.xmlgraphics/batik-script/1.18, Apache-2.0, approved, #16577
+maven/mavencentral/org.apache.xmlgraphics/batik-shared-resources/1.18, Apache-2.0, approved, #16599
+maven/mavencentral/org.apache.xmlgraphics/batik-svg-dom/1.18, Apache-2.0 AND W3C, approved, #16579
+maven/mavencentral/org.apache.xmlgraphics/batik-svggen/1.18, Apache-2.0, approved, #16595
+maven/mavencentral/org.apache.xmlgraphics/batik-svgrasterizer/1.18, Apache-2.0, approved, #16813
+maven/mavencentral/org.apache.xmlgraphics/batik-transcoder/1.18, Apache-2.0, approved, #16588
+maven/mavencentral/org.apache.xmlgraphics/batik-util/1.18, Apache-2.0, approved, #16578
+maven/mavencentral/org.apache.xmlgraphics/batik-xml/1.18, Apache-2.0, approved, #16581
+maven/mavencentral/org.apache.xmlgraphics/xmlgraphics-commons/2.10, Apache-2.0, approved, #16598
+maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, #17641
+maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
+maven/mavencentral/org.awaitility/awaitility/4.2.1, Apache-2.0, approved, #14178
+maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.79, MIT AND CC0-1.0, approved, #16964
 maven/mavencentral/org.checkerframework/checker-qual/3.33.0, MIT, approved, clearlydefined
+maven/mavencentral/org.codehaus.plexus/plexus-archiver/4.12.0, Apache-2.0, approved, #28645
+maven/mavencentral/org.codehaus.plexus/plexus-io/3.6.0, Apache-2.0, approved, #24660
+maven/mavencentral/org.codehaus.plexus/plexus-utils/3.6.1, Apache-2.0 AND Entessa AND Apache-1.1 AND BSD-3-Clause AND BSD-2-Clause AND SAX-PD AND LicenseRef-Public-Domain, approved, #21842
 maven/mavencentral/org.codehaus.woodstox/stax2-api/4.2.1, BSD-2-Clause, approved, #2670
-maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-dataformat-aasx/1.0.2, Apache-2.0, approved, dt.aas4j
-maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-dataformat-core/1.0.2, Apache-2.0, approved, dt.aas4j
-maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-dataformat-json/1.0.2, Apache-2.0, approved, dt.aas4j
-maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-dataformat-xml/1.0.2, Apache-2.0, approved, dt.aas4j
-maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-model/1.0.2, Apache-2.0, approved, dt.aas4j
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-meta-model-interface/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-meta-model-java/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-aas-generator/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-document-generators/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-generator/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-jackson/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-java-core/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-java-generator/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-serializer/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-starter/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-urn/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-validator/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-aspect-static-meta-model-java/2.9.8, MPL-2.0, approved, dt.esmf
-maven/mavencentral/org.eclipse.esmf/esmf-semantic-aspect-meta-model/2.1.0, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-dataformat-aasx/1.0.4, Apache-2.0, approved, dt.aas4j
+maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-dataformat-core/1.0.4, Apache-2.0, approved, dt.aas4j
+maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-dataformat-json/1.0.4, Apache-2.0, approved, dt.aas4j
+maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-dataformat-xml/1.0.4, Apache-2.0, approved, dt.aas4j
+maven/mavencentral/org.eclipse.digitaltwin.aas4j/aas4j-model/1.0.4, Apache-2.0, approved, dt.aas4j
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-meta-model-interface/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-meta-model-java/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-aas-generator/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-document-generators/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-generator/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-jackson/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-java-core/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-java-generator/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-starter/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-urn/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-model-validator/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-aspect-static-meta-model-java/2.10.3, MPL-2.0, approved, dt.esmf
+maven/mavencentral/org.eclipse.esmf/esmf-semantic-aspect-meta-model/2.2.0, MPL-2.0, approved, dt.esmf
 maven/mavencentral/org.eclipse.jetty.ee10.websocket/jetty-ee10-websocket-jakarta-client/12.0.8, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.ee10.websocket/jetty-ee10-websocket-jakarta-common/12.0.8, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty.ee10.websocket/jetty-ee10-websocket-jakarta-server/12.0.8, EPL-2.0 OR Apache-2.0, approved, rt.jetty
@@ -176,25 +209,54 @@ maven/mavencentral/org.eclipse.jetty/jetty-session/12.0.8, EPL-2.0 OR Apache-2.0
 maven/mavencentral/org.eclipse.jetty/jetty-util/12.0.8, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.eclipse.jetty/jetty-xml/12.0.8, EPL-2.0 OR Apache-2.0, approved, rt.jetty
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
-maven/mavencentral/org.graalvm.js/js-scriptengine/23.0.5, UPL-1.0, approved, #11524
-maven/mavencentral/org.graalvm.js/js/23.0.5, UPL-1.0 AND (LicenseRef-Permission-Notice AND UPL-1.0) AND ((GPL-2.0-only WITH Classpath-exception-2.0) AND UPL-1.0) AND (BSD-3-Clause AND UPL-1.0) AND (LicenseRef-Permission-Notice AND MPL-2.0), approved, #11528
-maven/mavencentral/org.graalvm.regex/regex/23.0.5, UPL-1.0, approved, #11529
-maven/mavencentral/org.graalvm.sdk/graal-sdk/23.0.5, UPL-1.0, approved, #9850
-maven/mavencentral/org.graalvm.truffle/truffle-api/23.0.5, UPL-1.0 AND (MIT AND UPL-1.0), approved, #11527
-maven/mavencentral/org.graphper/graph-support/1.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.graalvm.js/js-community/24.1.2, , restricted, clearlydefined
+maven/mavencentral/org.graalvm.js/js-language/24.1.2, , restricted, clearlydefined
+maven/mavencentral/org.graalvm.js/js-scriptengine/24.1.2, UPL-1.0, approved, #20103
+maven/mavencentral/org.graalvm.js/js/24.1.2, , restricted, clearlydefined
+maven/mavencentral/org.graalvm.polyglot/js/24.1.2, UPL-1.0, approved, #20101
+maven/mavencentral/org.graalvm.polyglot/polyglot/24.1.2, UPL-1.0, approved, #20104
+maven/mavencentral/org.graalvm.regex/regex/24.1.2, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.graalvm.sdk/collections/24.1.2, UPL-1.0, approved, #20090
+maven/mavencentral/org.graalvm.sdk/jniutils/24.1.2, , restricted, clearlydefined
+maven/mavencentral/org.graalvm.sdk/nativebridge/24.1.2, , restricted, clearlydefined
+maven/mavencentral/org.graalvm.sdk/nativeimage/24.1.2, UPL-1.0, approved, #20105
+maven/mavencentral/org.graalvm.sdk/word/24.1.2, UPL-1.0, approved, #20097
+maven/mavencentral/org.graalvm.shadowed/icu4j/24.1.2, LicenseRef-scancode-unicode-icu-58 AND LicenseRef-scancode-unicode AND GPL-2.0-or-later WITH Autoconf-exception-generic AND GPL-3.0-or-later WITH Autoconf-exception-generic-3.0 AND NTP, restricted, clearlydefined
+maven/mavencentral/org.graalvm.truffle/truffle-api/24.1.2, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.graalvm.truffle/truffle-compiler/24.1.2, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.graalvm.truffle/truffle-enterprise/24.1.2, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.graalvm.truffle/truffle-runtime/24.1.2, NOASSERTION, restricted, clearlydefined
+maven/mavencentral/org.graphper/graph-support-core/1.5.0, Apache-2.0, approved, #20089
+maven/mavencentral/org.hamcrest/hamcrest-core/2.2, BSD-3-Clause, approved, #23163
+maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, #17677
+maven/mavencentral/org.hdrhistogram/HdrHistogram/2.1.12, CC0-1.0, approved, #15259
 maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0 AND CC-PDDC, approved, #18198
-maven/mavencentral/org.jboss.forge.roaster/roaster-api/2.29.0.Final, EPL-1.0, approved, #11526
-maven/mavencentral/org.jboss.forge.roaster/roaster-jdt/2.29.0.Final, , approved, #11525
+maven/mavencentral/org.jboss.forge.roaster/roaster-api/2.30.1.Final, EPL-1.0, approved, #20093
+maven/mavencentral/org.jboss.forge.roaster/roaster-jdt/2.30.1.Final, EPL-2.0 AND (Apache-2.0 AND LGPL-2.1-or-later) AND Apache-2.0 AND EPL-1.0 AND (EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH LicenseRef-scancode-openjdk-exception), approved, #20100
 maven/mavencentral/org.jboss.logging/jboss-logging/3.5.3.Final, Apache-2.0, approved, #9471
 maven/mavencentral/org.jeasy/easy-random-core/5.0.0, MIT, approved, clearlydefined
+maven/mavencentral/org.jetbrains/annotations/17.0.0, Apache-2.0, approved, #19678
+maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.3, EPL-2.0, approved, #3133
+maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.3, EPL-2.0, approved, #3125
+maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.3, EPL-2.0, approved, #3134
+maven/mavencentral/org.junit.jupiter/junit-jupiter/5.9.3, EPL-2.0, approved, #6972
+maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.3, EPL-2.0, approved, #3130
+maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.3, EPL-2.0, approved, #3128
+maven/mavencentral/org.latencyutils/LatencyUtils/2.0.3, CC0-1.0, approved, #15280
 maven/mavencentral/org.mapstruct/mapstruct/1.5.3.Final, Apache-2.0, approved, #6277
-maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.mockito/mockito-core/5.7.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #11424
+maven/mavencentral/org.mockito/mockito-junit-jupiter/5.7.0, MIT, approved, #11423
+maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, #19727
 maven/mavencentral/org.openapitools/jackson-databind-nullable/0.1.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.opentest4j/opentest4j/1.2.0, Apache-2.0, approved, #17680
 maven/mavencentral/org.ow2.asm/asm-commons/9.7, BSD-3-Clause, approved, #16465
 maven/mavencentral/org.ow2.asm/asm-tree/9.7, BSD-3-Clause, approved, #16466
 maven/mavencentral/org.ow2.asm/asm/9.7, BSD-3-Clause, approved, #16464
-maven/mavencentral/org.projectlombok/lombok/1.18.34, MIT, approved, #15192
-maven/mavencentral/org.roaringbitmap/RoaringBitmap/1.0.5, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.owasp.encoder/encoder/1.3.1, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.projectlombok/lombok/1.18.38, MIT, approved, #15192
+maven/mavencentral/org.rnorth.duct-tape/duct-tape/1.0.8, MIT, approved, clearlydefined
+maven/mavencentral/org.roaringbitmap/RoaringBitmap/1.3.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.skyscreamer/jsonassert/1.5.1, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.slf4j/jcl-over-slf4j/2.0.7, MIT AND Apache-2.0, approved, #11889
 maven/mavencentral/org.slf4j/jul-to-slf4j/2.0.7, MIT, approved, #7698
 maven/mavencentral/org.slf4j/slf4j-api/2.0.7, MIT, approved, #5915
@@ -210,16 +272,20 @@ maven/mavencentral/org.springframework.boot/spring-boot-starter-jetty/3.2.5, Apa
 maven/mavencentral/org.springframework.boot/spring-boot-starter-json/3.2.5, Apache-2.0, approved, #11894
 maven/mavencentral/org.springframework.boot/spring-boot-starter-logging/3.2.5, Apache-2.0, approved, #11890
 maven/mavencentral/org.springframework.boot/spring-boot-starter-oauth2-resource-server/3.2.5, Apache-2.0, approved, #11931
+maven/mavencentral/org.springframework.boot/spring-boot-starter-test/3.2.5, Apache-2.0, approved, #12917
 maven/mavencentral/org.springframework.boot/spring-boot-starter-validation/3.2.5, Apache-2.0, approved, #12921
 maven/mavencentral/org.springframework.boot/spring-boot-starter-web/3.2.5, Apache-2.0, approved, #11916
 maven/mavencentral/org.springframework.boot/spring-boot-starter/3.2.5, Apache-2.0, approved, #11935
+maven/mavencentral/org.springframework.boot/spring-boot-test-autoconfigure/3.2.5, Apache-2.0, approved, #12920
+maven/mavencentral/org.springframework.boot/spring-boot-test/3.2.5, Apache-2.0, approved, #12916
 maven/mavencentral/org.springframework.boot/spring-boot/3.2.5, Apache-2.0, approved, #11752
 maven/mavencentral/org.springframework.security/spring-security-config/6.3.4, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.security/spring-security-core/6.3.4, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.springframework.security/spring-security-crypto/6.3.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.springframework.security/spring-security-core/6.3.4, Apache-2.0, approved, #20892
+maven/mavencentral/org.springframework.security/spring-security-crypto/6.3.4, Apache-2.0 AND ISC, approved, #20893
 maven/mavencentral/org.springframework.security/spring-security-oauth2-core/6.3.4, Apache-2.0, approved, #16892
 maven/mavencentral/org.springframework.security/spring-security-oauth2-jose/6.3.4, Apache-2.0, approved, #16884
 maven/mavencentral/org.springframework.security/spring-security-oauth2-resource-server/6.3.4, Apache-2.0, approved, #16888
+maven/mavencentral/org.springframework.security/spring-security-test/6.3.4, Apache-2.0, approved, #16974
 maven/mavencentral/org.springframework.security/spring-security-web/6.3.4, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.springframework/spring-aop/6.1.13, Apache-2.0, approved, #15221
 maven/mavencentral/org.springframework/spring-beans/6.1.13, Apache-2.0, approved, #15213
@@ -227,11 +293,16 @@ maven/mavencentral/org.springframework/spring-context/6.1.13, Apache-2.0, approv
 maven/mavencentral/org.springframework/spring-core/6.1.13, Apache-2.0 AND BSD-3-Clause, approved, #15206
 maven/mavencentral/org.springframework/spring-expression/6.1.13, Apache-2.0, approved, #15264
 maven/mavencentral/org.springframework/spring-jcl/6.1.13, Apache-2.0, approved, #15266
+maven/mavencentral/org.springframework/spring-test/6.1.13, Apache-2.0, approved, #15265
 maven/mavencentral/org.springframework/spring-web/6.1.13, Apache-2.0, approved, #15188
 maven/mavencentral/org.springframework/spring-webmvc/6.1.14, Apache-2.0, approved, #15182
+maven/mavencentral/org.testcontainers/junit-jupiter/1.21.4, MIT, approved, clearlydefined
+maven/mavencentral/org.testcontainers/testcontainers/1.21.4, MIT, approved, #20874
 maven/mavencentral/org.topbraid/shacl/1.3.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.tukaani/xz/1.12, 0BSD, approved, #26283
 maven/mavencentral/org.webjars/swagger-ui/4.15.5, Apache-2.0 AND MIT, approved, #5921
 maven/mavencentral/org.webjars/webjars-locator-core/0.55, MIT, approved, clearlydefined
+maven/mavencentral/org.xmlunit/xmlunit-core/2.9.1, Apache-2.0, approved, #6272
 maven/mavencentral/org.yaml/snakeyaml/2.0, Apache-2.0 AND (Apache-2.0 OR BSD-3-Clause OR EPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later), approved, #7275
 maven/mavencentral/xml-apis/xml-apis-ext/1.3.04, Apache-2.0, approved, CQ1448
 maven/mavencentral/xml-apis/xml-apis/1.4.01, Apache-2.0 OR LicenseRef-Public-Domain OR W3C, approved, CQ9621

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,11 +22,11 @@ If you have a running Kubernetes cluster available, you can deploy the Semantic 
 
 ## Precondition
 Build fuseki docker image by following the below steps :
-- Download [jena-fuseki-docker-5.0.0.zip](https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/5.0.0/jena-fuseki-docker-5.0.0.zip)
-- Unzip the jena-fuseki-docker-5.0.0.zip.
-- Build the docker image by running the command - `docker build --build-arg JENA_VERSION=5.0.0 -t jena-fuseki-docker:5.0.0 .`
+- Download [jena-fuseki-docker-5.3.0.zip](https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/5.3.0/jena-fuseki-docker-5.3.0.zip)
+- Unzip the jena-fuseki-docker-5.3.0.zip.
+- Build the docker image by running the command - `docker build --build-arg JENA_VERSION=5.3.0 -t jena-fuseki-docker:5.3.0 .`
 
-This docker image `jena-fuseki-docker:5.0.0` will be used in the Helm deployment and test - [values.yaml](charts/semantic-hub/values.yaml) (graphdb.image).
+This docker image `jena-fuseki-docker:5.3.0` will be used in the Helm deployment and test - [values.yaml](charts/semantic-hub/values.yaml) (graphdb.image).
 
 ## Install Instructions
 
@@ -81,7 +81,7 @@ The Helm Chart can be configured using the following parameters (incomplete list
 | ---             |---------------------------------------------------------------------------------------------------------|----------------------------|
 | `graphdb.enabled`     | Configures, whether a separate Fuseki Triplestore should be deployed in the cluster.                    | `true`                     |
 | `graphdb.storageClassName`     | Defines the storage class name of the `PersistentVolumeClaim` that is used to persist the GraphDB data. | `standard`                 |
-| `graphdb.image`     | Defines the fuseki docker image and version details.                                                    | `jena-fuseki-docker:5.0.0` |
+| `graphdb.image`     | Defines the fuseki docker image and version details.                                                    | `jena-fuseki-docker:5.3.0` |
 | `graphdb.storageSize`     | Size of the `PersistentVolumeClaim`                                                                     | `50Gi`                     |
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ The source code under this folder contains reference implementations of the SLDT
 
 ## Precondition
 Build fuseki docker image by following the below steps :
-- Download [jena-fuseki-docker-5.0.0.zip](https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/5.0.0/jena-fuseki-docker-5.0.0.zip)
-- Unzip the jena-fuseki-docker-5.0.0.zip.
-- Build the docker image by running the command - `docker build --build-arg JENA_VERSION=5.0.0 -t jena-fuseki-docker:5.0.0 .`
+- Download [jena-fuseki-docker-5.3.0.zip](https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/5.3.0/jena-fuseki-docker-5.3.0.zip)
+- Unzip the jena-fuseki-docker-5.3.0.zip.
+- Build the docker image by running the command - `docker build --build-arg JENA_VERSION=5.3.0 -t jena-fuseki-docker:5.3.0 .`
 
-This docker image `jena-fuseki-docker:5.0.0` will be used in the Helm deployment and test - [values.yaml](charts/semantic-hub/values.yaml) (graphdb.image).
+This docker image `jena-fuseki-docker:5.3.0` will be used in the Helm deployment and test - [values.yaml](charts/semantic-hub/values.yaml) (graphdb.image).
 
 ## Build Packages
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,12 +19,12 @@
 ###############################################################
 
 # Docker buildfile to containerize the semantics layer
-FROM maven:3-eclipse-temurin-17-alpine AS builder
+FROM maven:3-eclipse-temurin-21-alpine AS builder
 COPY . /build
 WORKDIR /build
 RUN mvn package -DskipTests
 
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 RUN addgroup -g 101 -S spring \
     && adduser -u 100 -S spring -G spring \

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/hub/ModelsApiTest.java
@@ -118,7 +118,7 @@ public class ModelsApiTest extends AbstractModelsApiTest{
          .andDo( MockMvcResultHandlers.print() )
          .andExpect( jsonPath( "$.error.message", containsString("Validation failed" ) ) )
             .andExpect( jsonPath( "$.error.details.validationError", containsString(
-                  "Resource urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#bool has no type" ) ) )
+                  "Resource urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#bool has no type" ) ) )
          .andExpect( status().is4xxClientError() );
    }
 
@@ -532,7 +532,7 @@ public class ModelsApiTest extends AbstractModelsApiTest{
 
       mvc.perform(post( insertModelJson ))
             .andDo( MockMvcResultHandlers.print() )
-				.andExpect( jsonPath( "$.error.details.validationError", containsString("Resource urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#Bool has no type" ) ) )
+				.andExpect( jsonPath( "$.error.details.validationError", containsString("Resource urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#Bool has no type" ) ) )
 				.andExpect( status().is4xxClientError() );
    }
 
@@ -1076,6 +1076,41 @@ public class ModelsApiTest extends AbstractModelsApiTest{
                 .andExpect( jsonPath( "$.error.message", containsString("Validation failed" ) ) )
                 .andExpect( jsonPath( "$.error.details.validationError", containsString("TripleStoreResolutionStrategy: definition for urn:samm:io.catenax.shared.quantity:1.0.0#VolumeCharacteristic not found" ) ) )
                 .andExpect( status().is4xxClientError() );
+    }
+
+    @Test
+    public void testSaveSamm220ModelExpectSuccess() throws Exception {
+        String HANDOVER_DOCUMENTATION_FILE = "HandoverDocumentation-1.0.0.ttl";
+        String urn = "urn:samm:io.admin-shell.idta.batterypass.handover_documentation:1.0.0#HandoverDocumentation";
+
+        mvc.perform( post( TestUtils.getTTLFile( HANDOVER_DOCUMENTATION_FILE ), "DRAFT" ) )
+                .andDo( MockMvcResultHandlers.print() )
+                .andExpect( status().isOk() )
+                .andExpect( jsonPath( "$.urn", is( urn ) ) )
+                .andExpect( jsonPath( "$.version", is( "1.0.0" ) ) )
+                .andExpect( jsonPath( "$.name", is( "HandoverDocumentation" ) ) )
+                .andExpect( jsonPath( "$.type", is( "SAMM" ) ) )
+                .andExpect( jsonPath( "$.status", is( "DRAFT" ) ) );
+
+        // the stored turtle file must keep the SAMM 2.2.0 meta model version
+        mvc.perform( MockMvcRequestBuilders.get( "/api/v1/models/{urn}/file", urn )
+                        .with( jwtTokenFactory.allRoles() ) )
+                .andDo( MockMvcResultHandlers.print() )
+                .andExpect( status().isOk() )
+                .andExpect( content().string( containsString( "urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0" ) ) );
+
+        mvc.perform( MockMvcRequestBuilders.get( "/api/v1/models/{urn}/json-schema", urn )
+                        .with( jwtTokenFactory.allRoles() ) )
+                .andDo( MockMvcResultHandlers.print() )
+                .andExpect( status().isOk() )
+                .andExpect( jsonPath( "$.description",
+                        containsString( "Handover Documentation defines a set of meta data" ) ) );
+
+        mvc.perform( MockMvcRequestBuilders.get( "/api/v1/models/{urn}/example-payload", urn )
+                        .with( jwtTokenFactory.allRoles() ) )
+                .andDo( MockMvcResultHandlers.print() )
+                .andExpect( status().isOk() )
+                .andExpect( jsonPath( "$.Documents" ).exists() );
     }
 
     @Test

--- a/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/DigitalProductPassport-3.0.0.ttl
+++ b/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/DigitalProductPassport-3.0.0.ttl
@@ -226,14 +226,12 @@
 :predecessor a samm:Property ;
    samm:preferredName "Predecessor"@en ;
    samm:description "Identification of the preceding product passport. This could either be an identification of the registered twin, a redirection to a platform where it is available, or if there is no preceding passport, input null."@en ;
-   samm:characteristic :IdentificationEither ;
-   samm:exampleValue "null" .
+   samm:characteristic :IdentificationEither .
 
 :passportIdentifier a samm:Property ;
    samm:preferredName "passportIdentifier"@en ;
    samm:description "The identifier of the product passport, which could be a uuidv4."@en ;
-   samm:characteristic :IdentificationEither ;
-   samm:exampleValue "urn:uuid:550e8400-e29b-41d4-a716-446655440000" .
+   samm:characteristic :IdentificationEither .
 
 :longName a samm:Property ;
    samm:preferredName "Long Name"@en ;
@@ -1118,8 +1116,7 @@
 :businessIdentifier a samm:Property ;
    samm:preferredName "Business Identifier"@en ;
    samm:description "The identifier used for a company address."@en ;
-   samm:characteristic :EitherIdentifier ;
-   samm:exampleValue "BPNL1234567890AA" .
+   samm:characteristic :EitherIdentifier .
 
 :businessIdentifierType a samm:Property ;
    samm:preferredName "Business Identifier Type"@en ;
@@ -1165,8 +1162,7 @@
 :locationIdentifier a samm:Property ;
    samm:preferredName "Location Identifier"@en ;
    samm:description "The identifier used for a location."@en ;
-   samm:characteristic :EitherLocationIdentifier ;
-   samm:exampleValue "BPNA1234567890AA" .
+   samm:characteristic :EitherLocationIdentifier .
 
 :locationIdentifierType a samm:Property ;
    samm:preferredName "location Identifier Type"@en ;

--- a/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/DigitalProductPassport-bamm.ttl
+++ b/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/DigitalProductPassport-bamm.ttl
@@ -602,8 +602,7 @@
 :concentration a bamm:Property;
     bamm:preferredName "Concentration"@en;
     bamm:description "Concentration of substances of concern at the level of the product."@en;
-    bamm:characteristic :Either;
-    bamm:exampleValue "13.6".
+    bamm:characteristic :Either.
 :ConcentrationEnumeration a bamm-c:Enumeration;
     bamm:preferredName "Concentration Enumeration"@en;
     bamm:description "Enumeration of possible units of concentration with percent, volume percent, parts per thousand, parts per million, parts per billion and parts per trillion."@en;

--- a/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/HandoverDocumentation-1.0.0.ttl
+++ b/backend/src/test/resources/org/eclipse/tractusx/semantics/hub/persistence/models/HandoverDocumentation-1.0.0.ttl
@@ -1,0 +1,147 @@
+######################################################################
+# Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2025 Industrial Digital Twin Association
+#
+# This work  is made available under the terms of the
+# Creative Commons Attribution 4.0 International (CC BY 4.0) license,
+# which is available at
+# https://creativecommons.org/licenses/by/4.0/.
+# SPDX-License-Identifier: CC-BY-4.0
+#######################################################################
+
+
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.2.0#> .
+@prefix samm-e: <urn:samm:org.eclipse.esmf.samm:entity:2.2.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.2.0#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <urn:samm:io.admin-shell.idta.batterypass.handover_documentation:1.0.0#> .
+@prefix docu: <urn:samm:io.admin-shell.idta.handover_documentation:2.0.0#> .
+@prefix shared: <urn:samm:io.admin-shell.idta.shared:3.1.0#> .
+
+:HandoverDocumentation a samm:Aspect ;
+   samm:preferredName "handover documentation of battery passport"@en ;
+   samm:preferredName "Übergabe-Dokumentation des Batteriepasses"@de ;
+   samm:description "Handover Documentation defines a set of meta data for the handover of documentation from the operator to the users of the Battery Passport."@en ;
+   samm:description "Enthält alle wichtigen Dokumente für den Kunden wie vom Batteriepass gefordert."@de ;
+   samm:see <urn:irdi:0173-1%2301-AHF578%23003> ;
+   samm:see <https://api.eclass-cdp.com/0173-1-01-AHF578-003> ;
+   samm:properties ( 
+   [ samm:property :documents; samm:payloadName "Documents" ] 
+   ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+
+
+:documents a samm:Property ;
+   samm:preferredName "documents"@en ;
+   samm:preferredName "Dokumente"@de ;
+   samm:description "A set of relevant documents to hand over to customers for documentation purposes."@en ;
+   samm:see <urn:irdi:0173-1%2302-ABI500%23003> ;
+   samm:see <https://api.eclass-cdp.com/0173-1-02-ABI500-003> ;
+   samm:characteristic :DocumentSet .
+   
+:DocumentSet a samm-c:Set ;
+   samm:see <https://admin-shell.io/vdi/2770/1/0/EntityForDocumentation> ;
+   samm:dataType :Document .
+   
+:Document a samm:Entity ;
+   samm:properties ( 
+     [ samm:property docu:documentIds; samm:payloadName "DocumentIds" ] 
+	 [ samm:property docu:documentClassifications; samm:payloadName "DocumentClassifications" ] 
+	 [ samm:property :documentVersions; samm:payloadName "DocumentVersions" ] 
+	 ) ;
+   samm:description "A single handover document."@en ;
+   samm:see <0173-1%2302-ABI500%23003/0173-1%2301-AHF579%23003> ;
+   samm:see <https://api.eclass-cdp.com/0173-1-02-ABI500-003/0173-1-01-AHF579-003> .
+
+:documentVersions a samm:Property ;
+   samm:preferredName "document versions"@en ;
+   samm:preferredName "Dokumenten-Versionen"@de ;
+   samm:description "Information elements of individual VDI 2770 DocumentVersion entities.\nNote: at the time of handover, this collection shall include at least one DocumentVersion."@en ;
+   samm:description "Liste der Dokument-Versionen."@de ;
+   samm:see <0173-1%2302-ABI503%23003> ;
+   samm:see <https://api.eclass-cdp.com/0173-1-02-ABI503-003> ;
+   samm:characteristic :DocumentVersionsTrait .
+
+:DocumentVersionsTrait a samm-c:Trait ;
+   samm-c:baseCharacteristic :DocumentVersions ;
+   samm-c:constraint shared:CardinalityOneToMany .
+   
+:DocumentVersions a samm-c:Set ;
+   samm:dataType :DocumentVersion .
+ 
+:DocumentVersion a samm:Entity ;
+   samm:preferredName "Dokumenten-Version"@de ;
+   samm:preferredName "document version"@en ;
+   samm:see <urn:irdi:0173-1%2302-ABI502%23003/0173-1%2301-AHF581%23003> ;
+   samm:properties ( 
+     [ samm:property shared:languages; samm:payloadName "Language" ] 
+	 [ samm:property docu:version; samm:optional true; samm:payloadName "Version" ] 
+	 [ samm:property docu:title; samm:payloadName "Title" ]
+	 [ samm:property docu:subtitle; samm:optional true; samm:payloadName "Subtitle" ] 
+	 [ samm:property docu:description; samm:optional true; samm:payloadName "Description" ]
+	 [ samm:property docu:digitalFiles; samm:payloadName "DigitalFiles" ]
+	 ) ;
+   samm:see <urn:irdi:0173-1%2302-ABI503%23003/0173-1%2301-AHF582%23003> ;
+   samm:see <https://api.eclass-cdp.com/0173-1-02-ABI503-003/0173-1-01-AHF582-003> .
+#######################################################################
+# Test-only addition: the original model at
+# https://github.com/admin-shell-io/smt-semantic-models references the
+# external namespaces io.admin-shell.idta.handover_documentation:2.0.0
+# and io.admin-shell.idta.shared:3.1.0. The referenced elements are
+# inlined below in reduced form so the model is self-contained and can
+# be uploaded without its dependency packages.
+#######################################################################
+
+docu:documentIds a samm:Property ;
+   samm:preferredName "document IDs"@en ;
+   samm:description "Set of document identifiers."@en ;
+   samm:characteristic samm-c:Text .
+
+docu:documentClassifications a samm:Property ;
+   samm:preferredName "document classifications"@en ;
+   samm:description "Set of classifications of the document."@en ;
+   samm:characteristic samm-c:Text .
+
+docu:version a samm:Property ;
+   samm:preferredName "version"@en ;
+   samm:description "The version of the document."@en ;
+   samm:characteristic samm-c:Text .
+
+docu:title a samm:Property ;
+   samm:preferredName "title"@en ;
+   samm:description "The title of the document."@en ;
+   samm:characteristic samm-c:MultiLanguageText .
+
+docu:subtitle a samm:Property ;
+   samm:preferredName "subtitle"@en ;
+   samm:description "The subtitle of the document."@en ;
+   samm:characteristic samm-c:MultiLanguageText .
+
+docu:description a samm:Property ;
+   samm:preferredName "description"@en ;
+   samm:description "The description of the document."@en ;
+   samm:characteristic samm-c:MultiLanguageText .
+
+docu:digitalFiles a samm:Property ;
+   samm:preferredName "digital files"@en ;
+   samm:description "Digital files of the document version."@en ;
+   samm:characteristic samm-c:Text .
+
+shared:languages a samm:Property ;
+   samm:preferredName "languages"@en ;
+   samm:description "Languages used in the document version."@en ;
+   samm:characteristic shared:LanguageSet .
+
+shared:LanguageSet a samm-c:Set ;
+   samm:preferredName "language set"@en ;
+   samm:description "Set of language codes."@en ;
+   samm:dataType xsd:string .
+
+shared:CardinalityOneToMany a samm-c:LengthConstraint ;
+   samm:preferredName "cardinality one to many"@en ;
+   samm:description "The collection must contain at least one element."@en ;
+   samm-c:minValue "1"^^xsd:nonNegativeInteger .

--- a/charts/semantic-hub/Chart.yaml
+++ b/charts/semantic-hub/Chart.yaml
@@ -26,8 +26,8 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-semantic-hub
 
 type: application
-version: 0.5.0
-appVersion: 0.6.0
+version: 0.6.0
+appVersion: 0.7.0
 dependencies:
   - repository: https://charts.bitnami.com/bitnami
     name: keycloak

--- a/charts/semantic-hub/README.md
+++ b/charts/semantic-hub/README.md
@@ -34,7 +34,7 @@ helm install hub -n semantics ./charts/semantic-hub
 | graphdb.args[4] | string | `"/ds"`                                                                                                                                                                     |  |
 | graphdb.containerPort | int | `3030`                                                                                                                                                                      |  |
 | graphdb.enabled | bool | `false`                                                                                                                                                                     |  |
-| graphdb.image | string | `"ghcr.io/catenax-ev/jena-fuseki:4.7.0"`                                                                                                                                    |  |
+| graphdb.image | string | `"jena-fuseki-docker:5.3.0"`                                                                                                                                                |  |
 | graphdb.imagePullPolicy | string | `"IfNotPresent"`                                                                                                                                                            |  |
 | graphdb.javaOptions | string | `"-Xmx1048m -Xms1048m"`                                                                                                                                                     |  |
 | graphdb.password | string | `"admin"`                                                                                                                                                                   |  |

--- a/charts/semantic-hub/values.yaml
+++ b/charts/semantic-hub/values.yaml
@@ -79,7 +79,7 @@ hub:
 graphdb:
   ## Include Fuski deployment or deploy separately
   enabled: false
-  image: jena-fuseki-docker:5.0.0
+  image: jena-fuseki-docker:5.3.0
   imagePullPolicy: IfNotPresent
   replicaCount: 1
   containerPort: 3030

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
   # The image is not published on a registry and must be built locally first,
   # see the "Build the Fuseki image" step in the guide.
   graphdb:
-    image: jena-fuseki-docker:5.0.0
+    image: jena-fuseki-docker:5.3.0
     command: ["--tdb2", "--update", "--loc", "databases/", "/ds"]
     environment:
       JAVA_OPTIONS: "-Xmx1048m -Xms1048m"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+###############################################################
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+# Local deployment of the Semantic Hub and its dependencies.
+# See docs/local-deployment-docker-compose.md for the full guide.
+#
+#   docker compose up -d    -> hub + Fuseki triple store (no auth)
+
+services:
+
+  # Apache Jena Fuseki triple store ("graphdb" in the Helm chart).
+  # The image is not published on a registry and must be built locally first,
+  # see the "Build the Fuseki image" step in the guide.
+  graphdb:
+    image: jena-fuseki-docker:5.0.0
+    command: ["--tdb2", "--update", "--loc", "databases/", "/ds"]
+    environment:
+      JAVA_OPTIONS: "-Xmx1048m -Xms1048m"
+    volumes:
+      - fuseki-data:/fuseki/databases
+    ports:
+      # Optional: direct SPARQL access from the host (http://localhost:3030/ds)
+      - "3030:3030"
+
+  semantic-hub:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    image: semantic-hub:local
+    # The "local" Spring profile disables OAuth2 authentication, mirroring
+    # the Helm chart behaviour when hub.authentication=false.
+    command: ["--spring.profiles.active=local"]
+    environment:
+      HUB_TRIPLE_STORE_EMBEDDED_ENABLED: "false"
+      HUB_TRIPLE_STORE_BASE_URL: http://graphdb:3030/ds
+      HUB_TRIPLE_STORE_QUERY_ENDPOINT: query
+      HUB_TRIPLE_STORE_UPDATE_ENDPOINT: update
+      # Fuseki is started without authentication; the credentials only need
+      # to be present because the properties are mandatory in the application.
+      HUB_TRIPLE_STORE_USERNAME: admin
+      HUB_TRIPLE_STORE_PASSWORD: admin
+      HUB_GENERAL_IDM_PUBLIC_CLIENT_ID: default-client
+    ports:
+      - "4242:4242"
+    depends_on:
+      - graphdb
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4242/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
+volumes:
+  fuseki-data:

--- a/docs/local-deployment-docker-compose.md
+++ b/docs/local-deployment-docker-compose.md
@@ -1,0 +1,151 @@
+<!--
+    Copyright (c) 2026 Contributors to the Eclipse Foundation
+
+    See the NOTICE file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    This program and the accompanying materials are made available under the
+    terms of the Apache License, Version 2.0 which is available at
+    https://www.apache.org/licenses/LICENSE-2.0.
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+    License for the specific language governing permissions and limitations
+    under the License.
+
+    SPDX-License-Identifier: Apache-2.0
+-->
+
+# Local Deployment with Docker Compose
+
+This guide describes how to run the Semantic Hub and all of its dependencies
+locally with Docker Compose, as an alternative to the Helm/minikube deployment
+described in [INSTALL.md](../INSTALL.md). The [docker-compose.yml](../docker-compose.yml)
+at the repository root bundles the same services the Helm chart deploys:
+
+| Service        | Image                          | Purpose                                            | Host port |
+|----------------|--------------------------------|----------------------------------------------------|-----------|
+| `semantic-hub` | `semantic-hub:local` (built)   | The Semantic Hub backend                           | 4242      |
+| `graphdb`      | `jena-fuseki-docker:5.0.0`     | Apache Jena Fuseki triple store (persistent, TDB2) | 3030      |
+
+## Prerequisites
+
+- Docker with the Compose plugin (`docker compose version` ≥ 2.x)
+- `curl` and `unzip` for building the Fuseki image
+
+Maven and a JDK are **not** required on the host — the Semantic Hub is built
+inside a multi-stage Docker build.
+
+## Step 1: Build the Fuseki image
+
+The triple store image is not published on a public registry and must be built
+locally once (same precondition as for the Helm deployment):
+
+```bash
+curl -LO https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/5.0.0/jena-fuseki-docker-5.0.0.zip
+unzip jena-fuseki-docker-5.0.0.zip
+cd jena-fuseki-docker-5.0.0
+docker build --build-arg JENA_VERSION=5.0.0 -t jena-fuseki-docker:5.0.0 .
+cd ..
+```
+
+Verify the image exists:
+
+```bash
+docker image ls jena-fuseki-docker
+```
+
+## Step 2: Build and start the stack
+
+From the repository root:
+
+```bash
+docker compose up -d --build
+```
+
+This builds the Semantic Hub image from [backend/Dockerfile](../backend/Dockerfile)
+(Maven build inside the container, first run takes a few minutes) and starts:
+
+- **graphdb** — Fuseki with a persistent TDB2 dataset `/ds`, started with
+  `--tdb2 --update --loc databases/ /ds` (same arguments as the Helm chart).
+  Data is persisted in the named Docker volume `fuseki-data`.
+- **semantic-hub** — connected to Fuseki via `HUB_TRIPLE_STORE_BASE_URL=http://graphdb:3030/ds`.
+  Authentication is disabled via the `local` Spring profile, exactly like the
+  Helm chart does when `hub.authentication=false`.
+
+## Step 3: Verify the deployment
+
+Wait until both containers are up and the hub is healthy:
+
+```bash
+docker compose ps
+curl http://localhost:4242/actuator/health
+```
+
+Expected output: `{"status":"UP", ...}`.
+
+The hub needs a moment to start (the Helm probes allow ~100 s); follow the
+logs if it is not ready yet:
+
+```bash
+docker compose logs -f semantic-hub
+```
+
+## Step 4: Use the API
+
+- **Swagger UI**: <http://localhost:4242/>
+- **API base URL**: `http://localhost:4242/api/v1`
+- **Fuseki SPARQL endpoint** (direct triple store access): `http://localhost:3030/ds`
+
+Example — upload an aspect model and read it back:
+
+```bash
+# Create a minimal SAMM aspect model
+curl -X POST "http://localhost:4242/api/v1/models?type=SAMM&status=DRAFT" \
+  -H "Content-Type: text/plain" \
+  --data-binary @- <<'EOF'
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.2.0#> .
+@prefix : <urn:samm:org.example:1.0.0#> .
+
+:MyAspect a samm:Aspect ;
+   samm:preferredName "My Aspect"@en ;
+   samm:properties ( ) ;
+   samm:operations ( ) ;
+   samm:events ( ) .
+EOF
+
+# List all models
+curl "http://localhost:4242/api/v1/models"
+```
+
+## Step 5: Tear down
+
+```bash
+docker compose down          # stop containers, keep triple store data
+docker compose down -v       # stop containers and delete the Fuseki data volume
+```
+
+## Optional: In-memory triple store instead of Fuseki
+
+For a quick, non-persistent setup you can use the hub's embedded triple store
+and skip Fuseki entirely (equivalent to `hub.embeddedTripleStore=true` in the
+Helm chart). Set in `docker-compose.yml`:
+
+```yaml
+  semantic-hub:
+    environment:
+      HUB_TRIPLE_STORE_EMBEDDED_ENABLED: "true"
+```
+
+and start only the hub: `docker compose up -d --build semantic-hub`.
+All data is lost when the container restarts.
+
+## Troubleshooting
+
+- **`pull access denied for jena-fuseki-docker`** — the Fuseki image was not
+  built locally; repeat step 1.
+- **Hub logs connection errors to `graphdb`** — Fuseki may still be starting;
+  the hub recovers once Fuseki is reachable. Check `docker compose logs graphdb`.
+- **Port already in use** — adjust the host-side port mappings (`4242`, `3030`)
+  in `docker-compose.yml`.

--- a/docs/local-deployment-docker-compose.md
+++ b/docs/local-deployment-docker-compose.md
@@ -27,7 +27,7 @@ at the repository root bundles the same services the Helm chart deploys:
 | Service        | Image                          | Purpose                                            | Host port |
 |----------------|--------------------------------|----------------------------------------------------|-----------|
 | `semantic-hub` | `semantic-hub:local` (built)   | The Semantic Hub backend                           | 4242      |
-| `graphdb`      | `jena-fuseki-docker:5.0.0`     | Apache Jena Fuseki triple store (persistent, TDB2) | 3030      |
+| `graphdb`      | `jena-fuseki-docker:5.3.0`     | Apache Jena Fuseki triple store (persistent, TDB2) | 3030      |
 
 ## Prerequisites
 
@@ -43,10 +43,10 @@ The triple store image is not published on a public registry and must be built
 locally once (same precondition as for the Helm deployment):
 
 ```bash
-curl -LO https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/5.0.0/jena-fuseki-docker-5.0.0.zip
-unzip jena-fuseki-docker-5.0.0.zip
-cd jena-fuseki-docker-5.0.0
-docker build --build-arg JENA_VERSION=5.0.0 -t jena-fuseki-docker:5.0.0 .
+curl -LO https://repo1.maven.org/maven2/org/apache/jena/jena-fuseki-docker/5.3.0/jena-fuseki-docker-5.3.0.zip
+unzip jena-fuseki-docker-5.3.0.zip
+cd jena-fuseki-docker-5.3.0
+docker build --build-arg JENA_VERSION=5.3.0 -t jena-fuseki-docker:5.3.0 .
 cd ..
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<licence_distribution>repo</licence_distribution>
 		<licence_comments>An Eclipse Project</licence_comments>
 		<!-- build properties -->
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<maven.minimum.version>3.3.9</maven.minimum.version>
 
 		<!-- version properties -->
@@ -71,7 +71,7 @@
 		<springdoc.version>1.6.14</springdoc.version>
 		<springfox.version>2.9.2</springfox.version>
 		<collection-utlis.version>4.4</collection-utlis.version>
-		<lombok.version>1.18.34</lombok.version>
+		<lombok.version>1.18.38</lombok.version>
 		<javax-annotation-api.version>1.3.2</javax-annotation-api.version>
 		<swagger-annotations.version>1.5.20</swagger-annotations.version>
 		<swagger-core-version>2.0.0</swagger-core-version>
@@ -98,8 +98,8 @@
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 
 		<!-- semantics -->
-        <samm.sdk.version>2.9.8</samm.sdk.version>
-		<jena.version>5.0.0</jena.version>
+        <samm.sdk.version>2.10.3</samm.sdk.version>
+		<jena.version>5.3.0</jena.version>
 		<shacl.version>1.3.1</shacl.version>
 		<apache.http.client.version>4.5.12</apache.http.client.version>
 
@@ -110,10 +110,10 @@
 		<assertj.version>3.24.2</assertj.version>
 		<junit-jupiter.version>5.9.3</junit-jupiter.version>
 		<junit.version>4.13.2</junit.version>
-		<testcontainer.version>1.17.6</testcontainer.version>
+		<testcontainer.version>1.21.4</testcontainer.version>
 		<spring-security.version>6.3.4</spring-security.version>
 		<!-- build -->
-		<maven.compiler.version>3.8.1</maven.compiler.version>
+		<maven.compiler.version>3.13.0</maven.compiler.version>
 		<license-tool-plugin-version>1.1.0</license-tool-plugin-version>
 
 	</properties>


### PR DESCRIPTION
## Description

This PR upgrades the ESMF SDK from 2.9.8 to 2.10.3, adding support for aspect models written against SAMM 2.2.0 (esmf-semantic-aspect-meta-model 2.2.0).

Changes in detail:

- Upgrade ESMF SDK to 2.10.3 and the Jena client libraries to 5.3.0 (required by ESMF SDK 2.10.x).
- Upgrade the build to Java 21 (ESMF SDK 2.10.x is compiled for Java 21) in the Maven build, CI workflows and Docker images; update maven-compiler-plugin to 3.13.0 and lombok to 1.18.38.
- Update testcontainers to 1.21.4 for compatibility with current Docker Engine releases.
- Adapt validation message assertions to the SAMM 2.2.0 meta-model version reported after model migration.
- Fix the DigitalProductPassport test fixtures: they declared `samm:exampleValue` on properties whose characteristic is an `Either`. An `Either` characteristic has no `samm:dataType`, so an example value cannot be typed against it; ESMF SDK 2.10.x rejects such models during loading (`PropertyInstantiator` resolves the example value type via `characteristic.getDataType().orElseThrow()`), whereas older SDK versions silently tolerated them. The spec-invalid example values were removed.
- Add a test that uploads the IDTA battery pass HandoverDocumentation model (SAMM 2.2.0) and verifies model file retrieval, JSON schema and example payload generation.
- Add a docker-compose setup (Semantic Hub + Fuseki triple store) with a step-by-step guide in `docs/local-deployment-docker-compose.md` as an alternative to the Helm/minikube deployment for local testing.
- Regenerate DEPENDENCIES and update CHANGELOG.md.

The full backend test suite passes locally.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files

🤖 **Generated with Claude Code**